### PR TITLE
Centralize application version retrieval

### DIFF
--- a/bin/syntra
+++ b/bin/syntra
@@ -8,7 +8,7 @@ require_once dirname(__DIR__) . '/bootstrap.php';
 use Vix\Syntra\Application;
 
 try {
-    $application = new Application(version: '1.5.0');
+    $application = new Application(version: Application::getPackageVersion());
     $application->run();
 } catch (Throwable $e) {
     fwrite(STDERR, "CRITICAL ERROR: " . $e->getMessage() . "\n");

--- a/src/Application.php
+++ b/src/Application.php
@@ -15,9 +15,26 @@ class Application extends SymfonyApplication
 {
     private readonly ContainerInterface $container;
 
-    public function __construct(string $name = 'Syntra', string $version = '1.0.0')
+    private static ?string $packageVersion = null;
+
+    public static function getPackageVersion(): string
     {
-        parent::__construct($name, $version);
+        if (self::$packageVersion === null) {
+            $composerFile = dirname(__DIR__) . '/composer.json';
+            if (is_readable($composerFile)) {
+                $data = json_decode((string) file_get_contents($composerFile), true);
+                self::$packageVersion = $data['version'] ?? '0.0.0';
+            } else {
+                self::$packageVersion = '0.0.0';
+            }
+        }
+
+        return self::$packageVersion;
+    }
+
+    public function __construct(string $name = 'Syntra', string $version = '')
+    {
+        parent::__construct($name, $version ?: self::getPackageVersion());
 
         $this->container = ContainerFactory::create();
         $this->registerCommands();

--- a/src/Web/WebApplication.php
+++ b/src/Web/WebApplication.php
@@ -6,6 +6,7 @@ namespace Vix\Syntra\Web;
 
 use Exception;
 use ReflectionClass;
+use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DI\ContainerInterface;
 use Vix\Syntra\DI\ContainerFactory;
@@ -60,7 +61,7 @@ class WebApplication
     {
         $html = $this->renderTemplate('index.html', [
             'title' => 'Syntra Web Interface',
-            'version' => '1.5.0'
+            'version' => Application::getPackageVersion()
         ]);
 
         header('Content-Type: text/html');


### PR DESCRIPTION
## Summary
- add `Application::getPackageVersion()` helper to read the version from `composer.json`
- use new method in the CLI launcher
- display web interface version using the helper

## Testing
- `composer validate --no-check-all`
- `php bin/syntra --version`
- `php -l src/Web/WebApplication.php`
- `php -l bin/syntra`


------
https://chatgpt.com/codex/tasks/task_e_6867aa572ab48322b19bbfa0d778aa25