### PR TITLE
Add PHPUnit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-php@v4
+      - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: "8.2"
       - name: Install dependencies
         run: composer install --no-interaction --no-progress
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-php@v4
+        with:
+          php-version: '8.2'
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -256,6 +256,14 @@ Add to your CI pipeline:
       vendor/bin/syntra analyze:find-debug-calls
 ```
 
+### Running Tests
+
+Execute the PHPUnit test suite locally or in CI:
+
+```bash
+vendor/bin/phpunit
+```
+
 ## 🤝 Contributing
 
 Feel free to fork and contribute your own health checks, refactorers, or extensions via pull requests!

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Syntra Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit bootstrap="bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="Syntra Test Suite">
             <directory>tests</directory>

--- a/tests/Commands/FindTodosCommandTest.php
+++ b/tests/Commands/FindTodosCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\Analyze\FindTodosCommand;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class FindTodosCommandTest extends TestCase
+{
+    public function testDetectsTodoComments(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/sample.php', "<?php\n// TODO: fix me\n");
+
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+
+        $command = $app->find('analyze:find-todos');
+        $tester = new CommandTester($command);
+        $tester->execute(['--path' => $dir]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('TODO', $display);
+
+        unlink($dir . '/sample.php');
+        rmdir($dir);
+    }
+}

--- a/tests/DI/ContainerTest.php
+++ b/tests/DI/ContainerTest.php
@@ -1,0 +1,22 @@
+<?php
+namespace Vix\Syntra\Tests\DI;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\DI\Container;
+use Vix\Syntra\Tests\Fixtures\FooInterface;
+use Vix\Syntra\Tests\Fixtures\Foo;
+use Vix\Syntra\Tests\Fixtures\Bar;
+
+class ContainerTest extends TestCase
+{
+    public function testResolvesDependencies(): void
+    {
+        $container = new Container();
+        $container->bind(FooInterface::class, Foo::class);
+
+        $bar = $container->make(Bar::class);
+
+        $this->assertInstanceOf(Bar::class, $bar);
+        $this->assertSame('foo', $bar->foo->name());
+    }
+}

--- a/tests/Fixtures/Bar.php
+++ b/tests/Fixtures/Bar.php
@@ -1,0 +1,3 @@
+<?php
+namespace Vix\Syntra\Tests\Fixtures;
+class Bar { public function __construct(public FooInterface $foo) {} }

--- a/tests/Fixtures/Foo.php
+++ b/tests/Fixtures/Foo.php
@@ -1,0 +1,3 @@
+<?php
+namespace Vix\Syntra\Tests\Fixtures;
+class Foo implements FooInterface { public function name(): string { return 'foo'; } }

--- a/tests/Fixtures/FooInterface.php
+++ b/tests/Fixtures/FooInterface.php
@@ -1,0 +1,3 @@
+<?php
+namespace Vix\Syntra\Tests\Fixtures;
+interface FooInterface { public function name(): string; }

--- a/tests/Utils/ProcessRunnerTest.php
+++ b/tests/Utils/ProcessRunnerTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Vix\Syntra\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Utils\ProcessRunner;
+
+class ProcessRunnerTest extends TestCase
+{
+    public function testRunSuccessfulCommand(): void
+    {
+        $runner = new ProcessRunner();
+        $result = $runner->run('php', ['-r', 'echo "hello";']);
+
+        $this->assertSame(0, $result->exitCode);
+        $this->assertSame('hello', trim($result->output));
+    }
+
+    public function testRunFails(): void
+    {
+        $runner = new ProcessRunner();
+        $result = $runner->run('php', ['-r', 'fwrite(STDERR, "err"); exit(1);']);
+
+        $this->assertSame(1, $result->exitCode);
+        $this->assertSame('err', trim($result->stderr));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-declare(strict_types=1);
-require __DIR__ . '/../bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../bootstrap.php';


### PR DESCRIPTION
## Summary
- set up PHPUnit with simple config
- add tests for Container, ProcessRunner and FindTodosCommand
- document running tests
- add GitHub Actions workflow to run PHPUnit

## Testing
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6867abeb9e548322b2e2f4ce0a1732aa