### PR TITLE
Add yii:all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ All commands support these standard options:
 
 | Command                        | Description                                                                                          | Danger Level | Options                          |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------ | -------------------------------- |
+| `yii:all`                      | Runs all Yii-specific Rector refactorings in sequence | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `yii:find-shortcuts`           | Converts `Model::find()->where([...])->one()/all()` into `Model::findOne([...])` or `findAll([...])` | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `yii:find-id`                  | Replaces `Model::findOne(['id' => $id])` with `Model::findOne($id)`                                  | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `yii:update-shortcut`          | Replaces `Model::find()->where([...])->update([...])` with `Model::updateAll([...], [...])`          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |

--- a/config.php
+++ b/config.php
@@ -23,6 +23,7 @@ use Vix\Syntra\Commands\Extension\Yii\YiiConvertAccessChainCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiDeleteShortcutCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiFindIdCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiFindShortcutsCommand;
+use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiUpdateShortcutCommand;
 use Vix\Syntra\Commands\General\GenerateCommandCommand;
 use Vix\Syntra\Commands\General\GenerateDocsCommand;
@@ -136,6 +137,10 @@ return [
         ],
     ],
     'yii' => [
+        YiiAllCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
         YiiFindShortcutsCommand::class => [
             'enabled' => true,
             'web_enabled' => true,

--- a/src/Commands/Extension/Yii/YiiAllCommand.php
+++ b/src/Commands/Extension/Yii/YiiAllCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Extension\Yii;
+
+use Vix\Syntra\Commands\Rector\CanHelpersRector;
+use Vix\Syntra\Commands\Rector\ConvertAccessChainRector;
+use Vix\Syntra\Commands\Rector\DeleteAllShortcutRector;
+use Vix\Syntra\Commands\Rector\FindOneFindAllShortcutRector;
+use Vix\Syntra\Commands\Rector\FindOneIdShortcutRector;
+use Vix\Syntra\Commands\Rector\UpdateAllShortcutRector;
+use Vix\Syntra\Commands\Rector\UserFindOneToIdentityRector;
+
+class YiiAllCommand extends YiiRectorCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('yii:all')
+            ->setDescription('Runs all Yii-specific Rector refactorings in sequence')
+            ->setHelp('');
+    }
+
+    protected function getRectorRules(): array
+    {
+        return [
+            FindOneFindAllShortcutRector::class,
+            FindOneIdShortcutRector::class,
+            UpdateAllShortcutRector::class,
+            DeleteAllShortcutRector::class,
+            CanHelpersRector::class,
+            ConvertAccessChainRector::class,
+            UserFindOneToIdentityRector::class,
+        ];
+    }
+
+    protected function getSuccessMessage(): string
+    {
+        return 'All Yii Rector refactorings completed.';
+    }
+
+    protected function getErrorMessage(): string
+    {
+        return 'Yii Rector refactoring crashed.';
+    }
+}


### PR DESCRIPTION
## Summary
- add `yii:all` command to run all Yii Rector refactorings
- enable the new command in default config
- document the command in README

## Testing
- `vendor/bin/phpunit`
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6867be2409a08322a64a62888d73e522