### PR TITLE
Add no-progress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ All commands support these standard options:
 -   `--path`: Specify the root path of the project (defaults to current directory)
 -   `--dry-run` / `-d`: Preview changes without applying them
 -   `--force` / `-f`: Force execution, ignore warnings (refactor commands only)
+-   `--no-progress`: Disable progress output
 -   `--help` / `-h`: Display help for the command
 -   `--quiet` / `-q`: Only show errors
 -   `--verbose` / `-v/-vv/-vvv`: Increase verbosity level

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -23,6 +23,7 @@ abstract class SyntraCommand extends Command
     protected InputInterface $input;
 
     protected bool $dryRun = false;
+    protected bool $noProgress = false;
 
     protected ProgressIndicatorInterface $progressIndicator;
 
@@ -42,7 +43,8 @@ abstract class SyntraCommand extends Command
     {
         $this
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Root path of the project', null)
-            ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not apply changes, only show what would be done');
+            ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not apply changes, only show what would be done')
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disable progress output');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -51,6 +53,7 @@ abstract class SyntraCommand extends Command
         $this->output = new SymfonyStyle($input, $output);
 
         $this->dryRun = (bool) $input->getOption('dry-run');
+        $this->noProgress = (bool) $input->getOption('no-progress');
 
         if ($input->getOption('path')) {
             $this->configLoader->setProjectRoot((string) $input->getOption('path'));
@@ -66,8 +69,10 @@ abstract class SyntraCommand extends Command
 
     protected function startProgress(): void
     {
+        $type = $this->noProgress ? ProgressIndicatorFactory::TYPE_NONE : $this->progressType;
+
         $this->progressIndicator = ProgressIndicatorFactory::create(
-            $this->progressType,
+            $type,
             $this->output,
             $this->progressMax,
         );

--- a/src/ProgressIndicators/NullProgressIndicator.php
+++ b/src/ProgressIndicators/NullProgressIndicator.php
@@ -6,11 +6,23 @@ namespace Vix\Syntra\ProgressIndicators;
 
 class NullProgressIndicator implements ProgressIndicatorInterface
 {
-    public function start(): void {}
+    public function start(): void
+    {
+        //
+    }
 
-    public function advance(int $step = 1): void {}
+    public function advance(int $step = 1): void
+    {
+        //
+    }
 
-    public function finish(): void {}
+    public function finish(): void
+    {
+        //
+    }
 
-    public function setMessage(string $message): void {}
+    public function setMessage(string $message): void
+    {
+        //
+    }
 }

--- a/src/ProgressIndicators/NullProgressIndicator.php
+++ b/src/ProgressIndicators/NullProgressIndicator.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\ProgressIndicators;
+
+class NullProgressIndicator implements ProgressIndicatorInterface
+{
+    public function start(): void {}
+
+    public function advance(int $step = 1): void {}
+
+    public function finish(): void {}
+
+    public function setMessage(string $message): void {}
+}

--- a/src/ProgressIndicators/ProgressIndicatorFactory.php
+++ b/src/ProgressIndicators/ProgressIndicatorFactory.php
@@ -6,11 +6,13 @@ namespace Vix\Syntra\ProgressIndicators;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
+use Vix\Syntra\ProgressIndicators\NullProgressIndicator;
 
 class ProgressIndicatorFactory
 {
     public const TYPE_SPINNER = 'spinner';
     public const TYPE_PROGRESS_BAR = 'progress_bar';
+    public const TYPE_NONE = 'none';
 
     public static function create(
         string $type,
@@ -20,6 +22,7 @@ class ProgressIndicatorFactory
         return match ($type) {
             self::TYPE_PROGRESS_BAR => new ProgressBarIndicator($output, $maxSteps),
             self::TYPE_SPINNER => new SpinnerIndicator($output),
+            self::TYPE_NONE => new NullProgressIndicator(),
             default => new SpinnerIndicator($output),
         };
     }

--- a/src/ProgressIndicators/ProgressIndicatorFactory.php
+++ b/src/ProgressIndicators/ProgressIndicatorFactory.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Vix\Syntra\ProgressIndicators;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 use Vix\Syntra\ProgressIndicators\NullProgressIndicator;
+use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 
 class ProgressIndicatorFactory
 {

--- a/src/Utils/ConfigLoader.php
+++ b/src/Utils/ConfigLoader.php
@@ -15,7 +15,7 @@ class ConfigLoader
     public function __construct(?string $projectRoot = null)
     {
         $this->projectRoot = $projectRoot ?? getcwd();
-        $this->commands = require_once PACKAGE_ROOT . '/config.php';
+        $this->commands = require PACKAGE_ROOT . '/config.php';
     }
 
     public function setProjectRoot(string $path): void

--- a/tests/Commands/FindTodosCommandTest.php
+++ b/tests/Commands/FindTodosCommandTest.php
@@ -30,4 +30,27 @@ class FindTodosCommandTest extends TestCase
         unlink($dir . '/sample.php');
         rmdir($dir);
     }
+
+    public function testNoProgressOptionDisablesProgressBar(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/sample.php', "<?php\n// TODO: fix me\n");
+
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+
+        $command = $app->find('analyze:find-todos');
+        $tester = new CommandTester($command);
+        $tester->execute(['--path' => $dir, '--no-progress' => true]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringNotContainsString('Remaining:', $display);
+        $this->assertStringContainsString('TODO', $display);
+
+        unlink($dir . '/sample.php');
+        rmdir($dir);
+    }
 }


### PR DESCRIPTION
## Summary
- add `NullProgressIndicator` implementation
- extend progress indicator factory with `none` type
- add `--no-progress` option to commands
- ensure config loads multiple times correctly
- document the new option
- test disabling progress output

## Testing
- `vendor/bin/phpunit`