### PR TITLE
Add controller dir argument for docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All commands support these standard options:
 | Command                    | Description                                                                   | Options                                                  |
 | -------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
 | `general:generate-command` | Generates a scaffold for a new Symfony Console command                        | `--path`, `--dry-run`, `--group`, `--cli-name`, `--desc` |
-| `general:generate-docs`    | Scans Yii controllers and generates a markdown file listing all action routes | `--path`, `--dry-run`                                    |
+| `general:generate-docs`    | Scans Yii controllers and generates a markdown file listing all action routes | `--path`, `--dry-run`, `[controllerDir]` |
 
 ### 🧩 Yii Framework Extensions
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All commands support these standard options:
 | Command                    | Description                                                                   | Options                                                  |
 | -------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------- |
 | `general:generate-command` | Generates a scaffold for a new Symfony Console command                        | `--path`, `--dry-run`, `--group`, `--cli-name`, `--desc` |
-| `general:generate-docs`    | Scans Yii controllers and generates a markdown file listing all action routes | `--path`, `--dry-run`, `[controllerDir]` |
+| `general:generate-docs`    | Scans Yii controllers and generates a markdown file listing all action routes | `--path`, `--dry-run`, `[controllerDir]`                 |
 
 ### 🧩 Yii Framework Extensions
 

--- a/src/Commands/General/GenerateDocsCommand.php
+++ b/src/Commands/General/GenerateDocsCommand.php
@@ -8,6 +8,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Throwable;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\NodeVisitors\DocsVisitor;
@@ -28,13 +29,15 @@ class GenerateDocsCommand extends SyntraCommand
         $this
             ->setName('general:generate-docs')
             ->setDescription('Scans Yii controllers and generates a markdown file listing all action routes with optional descriptions.')
-            ->setHelp('Usage: vendor/bin/syntra general:generate-docs');
+            ->setHelp('Usage: vendor/bin/syntra general:generate-docs [controllerDir]')
+            ->addArgument('controllerDir', InputArgument::OPTIONAL, 'Relative path to controllers directory', 'backend/controllers');
     }
 
     public function perform(): int
     {
         $projectRoot = $this->configLoader->getProjectRoot();
-        $controllerDir = "$projectRoot/backend/controllers";
+        $controllerDirArg = $this->input->getArgument('controllerDir');
+        $controllerDir = $projectRoot . '/' . ltrim((string) ($controllerDirArg ?? 'backend/controllers'), '/');
 
         $fileHelper = $this->getService(FileHelper::class, fn (): FileHelper => new FileHelper());
         $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));


### PR DESCRIPTION
## Summary
- allow passing controller directory to `general:generate-docs`
- document new `controllerDir` argument

## Testing
- `vendor/bin/phpunit`