### PR TITLE
Implement SecurityChecker command

### DIFF
--- a/config.php
+++ b/config.php
@@ -22,7 +22,7 @@ use Vix\Syntra\Commands\Health\ComposerCheckCommand;
 use Vix\Syntra\Commands\Health\PhpStanCheckCommand;
 use Vix\Syntra\Commands\Health\PhpUnitCheckCommand;
 use Vix\Syntra\Commands\Health\ProjectCheckCommand;
-use Vix\Syntra\Commands\Health\SecurityChecker;
+use Vix\Syntra\Commands\Health\SecurityCheckCommand;
 use Vix\Syntra\Commands\Refactor\DocblockRefactorer;
 use Vix\Syntra\Commands\Refactor\ImportRefactorer;
 use Vix\Syntra\Commands\Refactor\PhpCsFixerRefactorer;
@@ -100,7 +100,7 @@ return [
             'enabled' => true,
             'web_enabled' => true,
         ],
-        SecurityChecker::class => [
+        SecurityCheckCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
         ],

--- a/config.php
+++ b/config.php
@@ -101,8 +101,8 @@ return [
             'web_enabled' => true,
         ],
         SecurityChecker::class => [
-            'enabled' => false,
-            'web_enabled' => false,
+            'enabled' => true,
+            'web_enabled' => true,
         ],
         ProjectCheckCommand::class => [
             'enabled' => true,

--- a/src/Commands/Health/SecurityCheckCommand.php
+++ b/src/Commands/Health/SecurityCheckCommand.php
@@ -10,7 +10,7 @@ use Vix\Syntra\DTO\CommandResult;
 use Vix\Syntra\Traits\ContainerAwareTrait;
 use Vix\Syntra\Traits\HandlesResultTrait;
 
-class SecurityChecker extends SyntraCommand implements HealthCheckCommandInterface
+class SecurityCheckCommand extends SyntraCommand implements HealthCheckCommandInterface
 {
     use ContainerAwareTrait;
     use HandlesResultTrait;

--- a/src/Commands/Health/SecurityChecker.php
+++ b/src/Commands/Health/SecurityChecker.php
@@ -4,7 +4,62 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Commands\Health;
 
-class SecurityChecker
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\DTO\CommandResult;
+use Vix\Syntra\Traits\ContainerAwareTrait;
+use Vix\Syntra\Traits\HandlesResultTrait;
+use Vix\Syntra\Commands\Health\HealthCheckCommandInterface;
+
+class SecurityChecker extends SyntraCommand implements HealthCheckCommandInterface
 {
-    //
+    use ContainerAwareTrait;
+    use HandlesResultTrait;
+
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->setName('health:security')
+            ->setDescription('Checks Composer dependencies for known security vulnerabilities.');
+    }
+
+    public function runCheck(): CommandResult
+    {
+        $result = $this->processRunner->run(
+            'composer',
+            ['audit', '--format=json'],
+            ['working_dir' => $this->configLoader->getProjectRoot()]
+        );
+
+        if ($result->exitCode !== 0) {
+            return CommandResult::error(["Composer audit failed:\n{$result->stderr}"]);
+        }
+
+        $json = json_decode($result->output, true);
+        if (!is_array($json) || !isset($json['advisories'])) {
+            return CommandResult::error(['Composer audit output is not parseable.']);
+        }
+
+        if (empty($json['advisories'])) {
+            return CommandResult::ok(['No security vulnerabilities found.']);
+        }
+
+        $messages = [];
+        foreach ($json['advisories'] as $package => $items) {
+            foreach ($items as $adv) {
+                $link = $adv['link'] ?? '';
+                $messages[] = trim("$package: $link");
+            }
+        }
+
+        return CommandResult::warning($messages);
+    }
+
+    public function perform(): int
+    {
+        $this->output->section('Running Composer security audit...');
+
+        $result = $this->runCheck();
+
+        return $this->handleResult($result, 'Composer security audit completed.');
+    }
 }

--- a/src/Commands/Health/SecurityChecker.php
+++ b/src/Commands/Health/SecurityChecker.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Commands\Health;
 
+use Vix\Syntra\Commands\Health\HealthCheckCommandInterface;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DTO\CommandResult;
 use Vix\Syntra\Traits\ContainerAwareTrait;
 use Vix\Syntra\Traits\HandlesResultTrait;
-use Vix\Syntra\Commands\Health\HealthCheckCommandInterface;
 
 class SecurityChecker extends SyntraCommand implements HealthCheckCommandInterface
 {

--- a/tests/Commands/SecurityCheckerTest.php
+++ b/tests/Commands/SecurityCheckerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Commands\Health\SecurityChecker;
+use Vix\Syntra\DTO\ProcessResult;
+use Vix\Syntra\Enums\CommandStatus;
+use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Utils\ExtensionManager;
+use Vix\Syntra\Utils\ProcessRunner;
+
+class SecurityCheckerTest extends TestCase
+{
+    private static ConfigLoader $config;
+    private static ExtensionManager $ext;
+
+    public static function setUpBeforeClass(): void
+    {
+        $ref = new \ReflectionClass(ConfigLoader::class);
+        /** @var ConfigLoader $cfg */
+        $cfg = $ref->newInstanceWithoutConstructor();
+
+        $propRoot = $ref->getProperty('projectRoot');
+        $propRoot->setAccessible(true);
+        $propRoot->setValue($cfg, sys_get_temp_dir());
+
+        $propCmd = $ref->getProperty('commands');
+        $propCmd->setAccessible(true);
+        $propCmd->setValue($cfg, require __DIR__ . '/../../config.php');
+
+        self::$config = $cfg;
+        self::$ext = new ExtensionManager(self::$config);
+    }
+
+    private function makeCommand(ProcessResult $result): SecurityChecker
+    {
+        $runner = new class($result) extends ProcessRunner {
+            public function __construct(private ProcessResult $result) {}
+            public function run(string $command, array $args = [], array $options = [], ?callable $callback = null): ProcessResult
+            {
+                return $this->result;
+            }
+        };
+
+        return new SecurityChecker(self::$config, $runner, self::$ext);
+    }
+
+    public function testOkWhenNoAdvisories(): void
+    {
+        $json = json_encode(['advisories' => [], 'abandoned' => []]);
+        $command = $this->makeCommand(new ProcessResult(0, $json, ''));
+        $result = $command->runCheck();
+
+        $this->assertSame(CommandStatus::OK, $result->status);
+    }
+
+    public function testWarningsWhenAdvisoriesPresent(): void
+    {
+        $json = json_encode([
+            'advisories' => [
+                'pkg/a' => [
+                    ['link' => 'https://example.com/a']
+                ],
+                'pkg/b' => [
+                    ['link' => 'https://example.com/b']
+                ],
+            ],
+        ]);
+
+        $command = $this->makeCommand(new ProcessResult(0, $json, ''));
+        $result = $command->runCheck();
+
+        $this->assertSame(CommandStatus::WARNING, $result->status);
+        $this->assertContains('pkg/a: https://example.com/a', $result->messages);
+        $this->assertContains('pkg/b: https://example.com/b', $result->messages);
+    }
+}

--- a/tests/Commands/SecurityCheckerTest.php
+++ b/tests/Commands/SecurityCheckerTest.php
@@ -3,7 +3,7 @@
 namespace Vix\Syntra\Tests\Commands;
 
 use PHPUnit\Framework\TestCase;
-use Vix\Syntra\Commands\Health\SecurityChecker;
+use Vix\Syntra\Commands\Health\SecurityCheckCommand;
 use Vix\Syntra\DTO\ProcessResult;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Utils\ConfigLoader;
@@ -33,7 +33,7 @@ class SecurityCheckerTest extends TestCase
         self::$ext = new ExtensionManager(self::$config);
     }
 
-    private function makeCommand(ProcessResult $result): SecurityChecker
+    private function makeCommand(ProcessResult $result): SecurityCheckCommand
     {
         $runner = new class($result) extends ProcessRunner {
             public function __construct(private ProcessResult $result) {}
@@ -43,7 +43,7 @@ class SecurityCheckerTest extends TestCase
             }
         };
 
-        return new SecurityChecker(self::$config, $runner, self::$ext);
+        return new SecurityCheckCommand(self::$config, $runner, self::$ext);
     }
 
     public function testOkWhenNoAdvisories(): void


### PR DESCRIPTION
## Summary
- implement `SecurityChecker` to run `composer audit`
- enable the command in the default configuration
- add tests that stub `ProcessRunner` to verify parsing

## Testing
- `vendor/bin/phpunit -c phpunit.xml`