### PR TITLE
Implement in-memory caching for file scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 -   **Static Analysis**: Detect todos, long methods, and unsafe debug calls.
 -   **Framework Support**: Built-in tooling for Yii (Laravel, Symfony planned).
 -   **Extensibility**: Generate and register new commands using stubs.
+-   **In-Memory Caching**: Reuses previously scanned file lists for faster repeated command execution.
 
 ## 📦 Installation
 

--- a/docs/DEPENDENCY_INJECTION.md
+++ b/docs/DEPENDENCY_INJECTION.md
@@ -78,6 +78,7 @@ Registers core application services:
 -   `ProcessRunner` - Process execution
 -   `ExtensionManager` - Extension management
 -   `FileHelper` - File operations
+    - caches results of file searches during a single run for performance
 
 ### HealthServiceProvider
 

--- a/src/Utils/FileHelper.php
+++ b/src/Utils/FileHelper.php
@@ -11,6 +11,10 @@ use SplFileInfo;
 class FileHelper
 {
     /**
+     * @var array<string, string[]>
+     */
+    private static array $filesCache = [];
+    /**
      * @param string[] $extensions
      * @param string[] $excludeDirs
      *
@@ -18,6 +22,11 @@ class FileHelper
      */
     public function collectFiles(string $dir, array $extensions = ['php'], array $excludeDirs = ['vendor', 'tests']): array
     {
+        $cacheKey = md5($dir . '|' . implode(',', $extensions) . '|' . implode(',', $excludeDirs));
+        if (isset(self::$filesCache[$cacheKey])) {
+            return self::$filesCache[$cacheKey];
+        }
+
         $files = [];
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir));
 
@@ -38,7 +47,7 @@ class FileHelper
             }
         }
 
-        return $files;
+        return self::$filesCache[$cacheKey] = $files;
     }
 
     /**


### PR DESCRIPTION
## Summary
- cache file search results per run
- document caching feature in README
- note caching behavior of FileHelper in DI docs

## Testing
- `./vendor/bin/phpunit`