### PR TITLE
Add cache reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 -   **Extensibility**: Generate and register new commands using stubs.
 -   **In-Memory Caching**: Reuses previously scanned file lists for faster repeated command execution.
 -   **Cache Reset**: Call `FileHelper::clearCache()` to manually reset cached file lists when working with temporary directories or tests.
+-   **No-Cache Option**: Use `--no-cache` to disable caching for a single command run.
 
 ## 📦 Installation
 
@@ -70,6 +71,7 @@ All commands support these standard options:
 -   `--dry-run` / `-d`: Preview changes without applying them
 -   `--force` / `-f`: Force execution, ignore warnings (refactor commands only)
 -   `--no-progress`: Disable progress output
+-   `--no-cache`: Disable file caching (useful for temporary directories)
 -   `--help` / `-h`: Display help for the command
 -   `--quiet` / `-q`: Only show errors
 -   `--verbose` / `-v/-vv/-vvv`: Increase verbosity level
@@ -80,37 +82,37 @@ All commands support these standard options:
 
 | Command                      | Description                                                                       | Options                        |
 | ---------------------------- | --------------------------------------------------------------------------------- | ------------------------------ |
-| `analyze:find-todos`         | Scans project files and collects all TODO, FIXME, @todo, @deprecated comments     | `--path`, `--dry-run`          |
-| `analyze:find-debug-calls`   | Checks that var_dump, dd, print_r, eval, and other calls prohibited in production | `--path`, `--dry-run`          |
-| `analyze:find-long-methods`  | Finds all methods or functions that exceed a specified number of lines            | `--path`, `--dry-run`, `--max` |
-| `analyze:find-bad-practices` | Detects bad practices in code like magic numbers, nested ternaries                | `--path`, `--dry-run`          |
+| `analyze:find-todos`         | Scans project files and collects all TODO, FIXME, @todo, @deprecated comments     | `--path`, `--dry-run`, `--no-cache`          |
+| `analyze:find-debug-calls`   | Checks that var_dump, dd, print_r, eval, and other calls prohibited in production | `--path`, `--dry-run`, `--no-cache`          |
+| `analyze:find-long-methods`  | Finds all methods or functions that exceed a specified number of lines            | `--path`, `--dry-run`, `--max`, `--no-cache` |
+| `analyze:find-bad-practices` | Detects bad practices in code like magic numbers, nested ternaries                | `--path`, `--dry-run`, `--no-cache`          |
 
 ### 🏥 Health
 
 | Command           | Description                                                  | Options               |
 | ----------------- | ------------------------------------------------------------ | --------------------- |
-| `health:composer` | Check Composer dependencies for updates                      | `--path`, `--dry-run` |
-| `health:phpstan`  | Run PHPStan static analysis                                  | `--path`, `--dry-run` |
-| `health:phpunit`  | Execute PHPUnit tests                                        | `--path`, `--dry-run` |
-| `health:security` | Check Composer dependencies for known vulnerabilities        | `--path`, `--dry-run` |
-| `health:project`  | Run all health checks (composer, phpstan, phpunit, security) | `--path`, `--dry-run` |
+| `health:composer` | Check Composer dependencies for updates                      | `--path`, `--dry-run`, `--no-cache` |
+| `health:phpstan`  | Run PHPStan static analysis                                  | `--path`, `--dry-run`, `--no-cache` |
+| `health:phpunit`  | Execute PHPUnit tests                                        | `--path`, `--dry-run`, `--no-cache` |
+| `health:security` | Check Composer dependencies for known vulnerabilities        | `--path`, `--dry-run`, `--no-cache` |
+| `health:project`  | Run all health checks (composer, phpstan, phpunit, security) | `--path`, `--dry-run`, `--no-cache` |
 
 ### 🔧 Refactor
 
 | Command                 | Description                                                       | Danger Level | Options                          |
 | ----------------------- | ----------------------------------------------------------------- | ------------ | -------------------------------- |
-| `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `--path`, `--dry-run`, `--force` |
-| `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `--path`, `--dry-run`, `--force` |
+| `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `--path`, `--dry-run`, `--no-cache`, `--force` |
 
 ### 🧠 General
 
 | Command                    | Description                                                                                                          | Options                                                  |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `general:generate-command` | Generates a scaffold for a new Symfony Console command                                                               | `--path`, `--dry-run`, `--group`, `--cli-name`, `--desc` |
-| `general:generate-docs`    | Scans project controllers and generates a markdown file listing all action routes (framework detected automatically) | `--path`, `--dry-run`, `[controllerDir]`                 |
+| `general:generate-command` | Generates a scaffold for a new Symfony Console command                                                               | `--path`, `--dry-run`, `--no-cache`, `--group`, `--cli-name`, `--desc` |
+| `general:generate-docs`    | Scans project controllers and generates a markdown file listing all action routes (framework detected automatically) | `--path`, `--dry-run`, `--no-cache`, `[controllerDir]`                 |
 
 ### 🧩 Yii Framework Extensions
 
@@ -124,8 +126,8 @@ All commands support these standard options:
 | `yii:delete-shortcut`          | Replaces `Model::find()->where([...])->delete()` with `Model::deleteAll([...])`                      | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `yii:can-helpers`              | Replaces `can()/!can()` chains with `canAny()`, `canAll()`, `cannotAny()`, or `cannotAll()`          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `yii:check-translations`       | Checks Yii::t translations: finds missing and unused keys across all categories                      | N/A          | `--path`, `--dry-run`, `--lang`  |
-| `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `--path`, `--dry-run`            |
-| `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `--path`, `--dry-run`            |
+| `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `--path`, `--dry-run`, `--no-cache`            |
+| `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `--path`, `--dry-run`, `--no-cache`            |
 
 ## 📁 Configuration
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 -   **Framework Support**: Built-in tooling for Yii (Laravel, Symfony planned).
 -   **Extensibility**: Generate and register new commands using stubs.
 -   **In-Memory Caching**: Reuses previously scanned file lists for faster repeated command execution.
+-   **Cache Reset**: Call `FileHelper::clearCache()` to manually reset cached file lists when working with temporary directories or tests.
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ All commands support these standard options:
 
 ### 🔍 Analyze
 
-| Command                      | Description                                                                       | Options                        |
-| ---------------------------- | --------------------------------------------------------------------------------- | ------------------------------ |
+| Command                      | Description                                                                       | Options                                      |
+| ---------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------- |
 | `analyze:find-todos`         | Scans project files and collects all TODO, FIXME, @todo, @deprecated comments     | `--path`, `--dry-run`, `--no-cache`          |
 | `analyze:find-debug-calls`   | Checks that var_dump, dd, print_r, eval, and other calls prohibited in production | `--path`, `--dry-run`, `--no-cache`          |
 | `analyze:find-long-methods`  | Finds all methods or functions that exceed a specified number of lines            | `--path`, `--dry-run`, `--max`, `--no-cache` |
@@ -89,8 +89,8 @@ All commands support these standard options:
 
 ### 🏥 Health
 
-| Command           | Description                                                  | Options               |
-| ----------------- | ------------------------------------------------------------ | --------------------- |
+| Command           | Description                                                  | Options                             |
+| ----------------- | ------------------------------------------------------------ | ----------------------------------- |
 | `health:composer` | Check Composer dependencies for updates                      | `--path`, `--dry-run`, `--no-cache` |
 | `health:phpstan`  | Run PHPStan static analysis                                  | `--path`, `--dry-run`, `--no-cache` |
 | `health:phpunit`  | Execute PHPUnit tests                                        | `--path`, `--dry-run`, `--no-cache` |
@@ -99,8 +99,8 @@ All commands support these standard options:
 
 ### 🔧 Refactor
 
-| Command                 | Description                                                       | Danger Level | Options                          |
-| ----------------------- | ----------------------------------------------------------------- | ------------ | -------------------------------- |
+| Command                 | Description                                                       | Danger Level | Options                                        |
+| ----------------------- | ----------------------------------------------------------------- | ------------ | ---------------------------------------------- |
 | `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
 | `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
 | `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
@@ -109,25 +109,25 @@ All commands support these standard options:
 
 ### 🧠 General
 
-| Command                    | Description                                                                                                          | Options                                                  |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Command                    | Description                                                                                                          | Options                                                                |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | `general:generate-command` | Generates a scaffold for a new Symfony Console command                                                               | `--path`, `--dry-run`, `--no-cache`, `--group`, `--cli-name`, `--desc` |
 | `general:generate-docs`    | Scans project controllers and generates a markdown file listing all action routes (framework detected automatically) | `--path`, `--dry-run`, `--no-cache`, `[controllerDir]`                 |
 
 ### 🧩 Yii Framework Extensions
 
-| Command                        | Description                                                                                          | Danger Level | Options                          |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------ | -------------------------------- |
-| `yii:all`                      | Runs all Yii-specific Rector refactorings in sequence                                                | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:find-shortcuts`           | Converts `Model::find()->where([...])->one()/all()` into `Model::findOne([...])` or `findAll([...])` | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:find-one-id`              | Replaces `Model::findOne(['id' => $id])` with `Model::findOne($id)`                                  | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:find-all-id`              | Replaces `Model::findAll(['id' => $id]) with Model::findAll($id)`                                    | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:update-shortcut`          | Replaces `Model::find()->where([...])->update([...])` with `Model::updateAll([...], [...])`          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:delete-shortcut`          | Replaces `Model::find()->where([...])->delete()` with `Model::deleteAll([...])`                      | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:can-helpers`              | Replaces `can()/!can()` chains with `canAny()`, `canAll()`, `cannotAny()`, or `cannotAll()`          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `yii:check-translations`       | Checks Yii::t translations: finds missing and unused keys across all categories                      | N/A          | `--path`, `--dry-run`, `--lang`  |
-| `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `--path`, `--dry-run`, `--no-cache`            |
-| `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `--path`, `--dry-run`, `--no-cache`            |
+| Command                        | Description                                                                                          | Danger Level | Options                             |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------ | ----------------------------------- |
+| `yii:all`                      | Runs all Yii-specific Rector refactorings in sequence                                                | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:find-shortcuts`           | Converts `Model::find()->where([...])->one()/all()` into `Model::findOne([...])` or `findAll([...])` | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:find-one-id`              | Replaces `Model::findOne(['id' => $id])` with `Model::findOne($id)`                                  | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:find-all-id`              | Replaces `Model::findAll(['id' => $id]) with Model::findAll($id)`                                    | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:update-shortcut`          | Replaces `Model::find()->where([...])->update([...])` with `Model::updateAll([...], [...])`          | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:delete-shortcut`          | Replaces `Model::find()->where([...])->delete()` with `Model::deleteAll([...])`                      | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:can-helpers`              | Replaces `can()/!can()` chains with `canAny()`, `canAll()`, `cannotAny()`, or `cannotAll()`          | 🟢 LOW       | `--path`, `--dry-run`, `--force`    |
+| `yii:check-translations`       | Checks Yii::t translations: finds missing and unused keys across all categories                      | N/A          | `--path`, `--dry-run`, `--lang`     |
+| `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `--path`, `--dry-run`, `--no-cache` |
+| `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `--path`, `--dry-run`, `--no-cache` |
 
 ## 📁 Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -246,6 +246,7 @@ vendor/bin/syntra analyze:find-todos --dry-run
 2. **Regular Review**: Periodically review and update your configuration
 3. **Version Control**: Keep `config.php` in version control
 4. **Environment Specific**: Consider different configs for dev/staging/production
+5. **Reset File Cache**: Use `FileHelper::clearCache()` when running tools on temporary directories or between test runs.
 
 ## Troubleshooting
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -246,7 +246,7 @@ vendor/bin/syntra analyze:find-todos --dry-run
 2. **Regular Review**: Periodically review and update your configuration
 3. **Version Control**: Keep `config.php` in version control
 4. **Environment Specific**: Consider different configs for dev/staging/production
-5. **Reset File Cache**: Use `FileHelper::clearCache()` when running tools on temporary directories or between test runs.
+5. **Reset File Cache**: Use `FileHelper::clearCache()` or run commands with `--no-cache` when working on temporary directories or between test runs.
 
 ## Troubleshooting
 

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -14,6 +14,7 @@ use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 use Vix\Syntra\Traits\HasStyledOutput;
 use Vix\Syntra\Utils\ConfigLoader;
 use Vix\Syntra\Utils\ProcessRunner;
+use Vix\Syntra\Utils\FileHelper;
 
 abstract class SyntraCommand extends Command
 {
@@ -23,6 +24,7 @@ abstract class SyntraCommand extends Command
 
     protected bool $dryRun = false;
     protected bool $noProgress = false;
+    protected bool $noCache = false;
 
     protected ProgressIndicatorInterface $progressIndicator;
 
@@ -42,7 +44,8 @@ abstract class SyntraCommand extends Command
         $this
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Root path of the project', null)
             ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not apply changes, only show what would be done')
-            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disable progress output');
+            ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disable progress output')
+            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Disable file caching');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -52,6 +55,9 @@ abstract class SyntraCommand extends Command
 
         $this->dryRun = (bool) $input->getOption('dry-run');
         $this->noProgress = (bool) $input->getOption('no-progress');
+        $this->noCache = (bool) $input->getOption('no-cache');
+
+        FileHelper::setCacheEnabled(!$this->noCache);
 
         if ($input->getOption('path')) {
             $this->configLoader->setProjectRoot((string) $input->getOption('path'));

--- a/src/Utils/FileHelper.php
+++ b/src/Utils/FileHelper.php
@@ -16,6 +16,14 @@ class FileHelper
     private static array $filesCache = [];
 
     /**
+     * Clears the internal files cache.
+     */
+    public static function clearCache(): void
+    {
+        self::$filesCache = [];
+    }
+
+    /**
      * @param string[] $extensions
      * @param string[] $excludeDirs
      *

--- a/src/Utils/FileHelper.php
+++ b/src/Utils/FileHelper.php
@@ -15,12 +15,23 @@ class FileHelper
      */
     private static array $filesCache = [];
 
+    private static bool $cacheEnabled = true;
+
     /**
      * Clears the internal files cache.
      */
     public static function clearCache(): void
     {
         self::$filesCache = [];
+    }
+
+    public static function setCacheEnabled(bool $enabled): void
+    {
+        self::$cacheEnabled = $enabled;
+
+        if (!$enabled) {
+            self::$filesCache = [];
+        }
     }
 
     /**
@@ -32,7 +43,7 @@ class FileHelper
     public function collectFiles(string $dir, array $extensions = ['php'], array $excludeDirs = ['vendor', 'tests']): array
     {
         $cacheKey = md5($dir . '|' . implode(',', $extensions) . '|' . implode(',', $excludeDirs));
-        if (isset(self::$filesCache[$cacheKey])) {
+        if (self::$cacheEnabled && isset(self::$filesCache[$cacheKey])) {
             return self::$filesCache[$cacheKey];
         }
 
@@ -56,7 +67,11 @@ class FileHelper
             }
         }
 
-        return self::$filesCache[$cacheKey] = $files;
+        if (self::$cacheEnabled) {
+            self::$filesCache[$cacheKey] = $files;
+        }
+
+        return $files;
     }
 
     /**

--- a/tests/Commands/FindTodosCommandTest.php
+++ b/tests/Commands/FindTodosCommandTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Utils\FileHelper;
 
 class FindTodosCommandTest extends TestCase
 {
@@ -14,6 +15,8 @@ class FindTodosCommandTest extends TestCase
         $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
         mkdir($dir);
         file_put_contents("$dir/sample.php", "<?php\n// TODO: fix me\n");
+
+        FileHelper::clearCache();
 
         $app = new Application();
         $container = $app->getContainer();
@@ -36,6 +39,8 @@ class FindTodosCommandTest extends TestCase
         $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
         mkdir($dir);
         file_put_contents("$dir/sample.php", "<?php\n// TODO: fix me\n");
+
+        FileHelper::clearCache();
 
         $app = new Application();
         $container = $app->getContainer();

--- a/tests/Utils/ProjectDetectorTest.php
+++ b/tests/Utils/ProjectDetectorTest.php
@@ -4,6 +4,7 @@ namespace Vix\Syntra\Tests\Utils;
 
 use PHPUnit\Framework\TestCase;
 use Vix\Syntra\Utils\ProjectDetector;
+use Vix\Syntra\Utils\FileHelper;
 
 class ProjectDetectorTest extends TestCase
 {
@@ -16,6 +17,8 @@ class ProjectDetectorTest extends TestCase
                 'yiisoft/yii2' => '*',
             ],
         ]));
+
+        FileHelper::clearCache();
 
         $detector = new ProjectDetector();
         $this->assertSame(ProjectDetector::TYPE_YII, $detector->detect($dir));
@@ -33,6 +36,8 @@ class ProjectDetectorTest extends TestCase
                 'some/package' => '*',
             ],
         ]));
+
+        FileHelper::clearCache();
 
         $detector = new ProjectDetector();
         $this->assertSame(ProjectDetector::TYPE_UNKNOWN, $detector->detect($dir));


### PR DESCRIPTION
## Summary
- add `clearCache()` to `FileHelper`
- clear the file cache in tests that create temporary directories
- document cache reset behavior in README and configuration docs

## Testing
- `vendor/bin/phpunit`