### PR TITLE
Add command options for Docblock metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ All commands support these standard options:
 | `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
 | `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--force` |
-| `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `--path`, `--dry-run`, `--force` |
+| `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `--path`, `--dry-run`, `--force`, `--author`, `--link`, `--category` |
 | `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `--path`, `--dry-run`, `--force` |
 
 ### 🧠 General

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ All commands support these standard options:
 
 ### 🔧 Refactor
 
-| Command                 | Description                                                       | Danger Level | Options                                        |
-| ----------------------- | ----------------------------------------------------------------- | ------------ | ---------------------------------------------- |
-| `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
-| `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
-| `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| Command                 | Description                                                       | Danger Level | Options                                                                            |
+| ----------------------- | ----------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------- |
+| `refactor:cs-fixer`     | Fixes code style using php-cs-fixer for the selected files        | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force`                                     |
+| `refactor:imports`      | Fixes incorrect order of docblocks and import statements          | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force`                                     |
+| `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `--path`, `--dry-run`, `--no-cache`, `--force`                                     |
 | `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `--path`, `--dry-run`, `--no-cache`, `--force`, `--author`, `--link`, `--category` |
-| `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `--path`, `--dry-run`, `--no-cache`, `--force` |
+| `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `--path`, `--dry-run`, `--no-cache`, `--force`                                     |
 
 ### 🧠 General
 

--- a/src/Commands/Refactor/DocblockRefactorer.php
+++ b/src/Commands/Refactor/DocblockRefactorer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands\Refactor;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
@@ -24,7 +25,10 @@ class DocblockRefactorer extends SyntraRefactorCommand
 
         $this->setName('refactor:docblocks')
             ->setDescription('Adds a file-level PHPDoc block to the beginning of the file and a PHPDoc block to each class if it is missing')
-            ->setHelp('Usage: vendor/bin/syntra refactor:docblocks [--dry-run] [--force]')
+            ->setHelp('Usage: vendor/bin/syntra refactor:docblocks [--dry-run] [--force] [--author=NAME] [--link=URL] [--category=CATEGORY]')
+            ->addOption('author', null, InputOption::VALUE_OPTIONAL, 'Value for the @author tag')
+            ->addOption('link', null, InputOption::VALUE_OPTIONAL, 'URL used for the @link tag')
+            ->addOption('category', null, InputOption::VALUE_OPTIONAL, 'Value for the @category tag')
             ->setDangerLevel(DangerLevel::MEDIUM);
     }
 
@@ -94,10 +98,10 @@ class DocblockRefactorer extends SyntraRefactorCommand
             if (!$hasDocBlock) {
                 $insertions[$i] = (new StubHelper("class-docblock"))->render([
                     'description' => str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath),
-                    'category' => 'Class',
-                    'author' => 'author <author@gmail.com>',
+                    'category' => (string) ($this->input->getOption('category') ?: 'Class'),
+                    'author' => (string) ($this->input->getOption('author') ?: 'author <author@gmail.com>'),
                     'copyright' => date('Y'),
-                    'link' => 'http://example.com/',
+                    'link' => (string) ($this->input->getOption('link') ?: 'http://example.com/'),
                 ]);
             }
         }
@@ -236,10 +240,10 @@ class DocblockRefactorer extends SyntraRefactorCommand
         $docBlock = (new StubHelper("file-docblock"))->render([
             'description' => str_replace(getcwd() . DIRECTORY_SEPARATOR, '', $filePath),
             'phpVersion' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
-            'category' => 'File',
-            'author' => 'author <author@gmail.com>',
+            'category' => (string) ($this->input->getOption('category') ?: 'File'),
+            'author' => (string) ($this->input->getOption('author') ?: 'author <author@gmail.com>'),
             'copyright' => date('Y'),
-            'link' => 'http://example.com/',
+            'link' => (string) ($this->input->getOption('link') ?: 'http://example.com/'),
         ]);
 
         return $firstToken[1] . "\n$docBlock" . $this->concatTokens(array_slice($tokens, 1));


### PR DESCRIPTION
## Summary
- add `--author`, `--link`, and `--category` options to DocblockRefactorer
- remove DocblockRefactorer config keys and docs
- use CLI options when generating docblocks
- document new options in README

## Testing
- `vendor/bin/phpunit`