### PR TITLE
Fix ImportRefactorer tests argument handling

### DIFF
--- a/tests/Commands/ImportRefactorerTest.php
+++ b/tests/Commands/ImportRefactorerTest.php
@@ -41,7 +41,8 @@ class ImportRefactorerTest extends TestCase
 
         $command = $app->find('refactor:imports');
         $tester = new CommandTester($command);
-        $tester->execute(["[path]" => $this->dir], $options);
+        $input = array_merge(['path' => $this->dir], $options);
+        $tester->execute($input);
     }
 
     public function testReordersHeaderBlocks(): void


### PR DESCRIPTION
## Summary
- fix ImportRefactorerTest to use `path` argument
- ensure options are passed correctly to the command

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686acea1277083228c95b52e7df88d55