### PR TITLE
Add Laravel dispatch shortcut rector command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ All commands support these standard options (with an optional `[path]` argument 
 | `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `[path]`, `--dry-run`, `--no-cache` |
 | `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `[path]`, `--dry-run`, `--no-cache` |
 
+### 🧩 Laravel Framework Extensions
+
+| Command                       | Description                                                         | Danger Level | Options                          |
+| ----------------------------- | ------------------------------------------------------------------- | ------------ | -------------------------------- |
+| `laravel:dispatch-shortcut`   | Rewrites `dispatch(new SomeJob($args))` to `SomeJob::dispatch($args)` | 🟢 LOW       | `[path]`, `--dry-run`, `--force` |
+
 ## 📁 Configuration
 
 Configuration is defined in PHP via `config.php`, allowing you to enable/disable commands or set options per tool. Example:
@@ -194,10 +200,11 @@ return [
 
 4. **Framework-Specific Optimizations** (Yii example):
     ```bash
-    vendor/bin/syntra yii:find-shortcuts --dry-run
-    vendor/bin/syntra yii:find-one-id --dry-run
-    vendor/bin/syntra yii:check-translations
-    ```
+vendor/bin/syntra yii:find-shortcuts --dry-run
+vendor/bin/syntra yii:find-one-id --dry-run
+vendor/bin/syntra yii:check-translations
+vendor/bin/syntra laravel:dispatch-shortcut --dry-run
+```
 
 ### Integration with CI/CD
 

--- a/config.php
+++ b/config.php
@@ -16,6 +16,7 @@ use Vix\Syntra\Commands\Extension\Yii\YiiFindOneIdCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiFindShortcutsCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiUpdateShortcutCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiUserFindoneToIdentityCommand;
+use Vix\Syntra\Commands\Extension\Laravel\LaravelDispatchShortcutCommand;
 use Vix\Syntra\Commands\General\GenerateCommandCommand;
 use Vix\Syntra\Commands\General\GenerateDocsCommand;
 use Vix\Syntra\Commands\Health\ComposerCheckCommand;
@@ -180,6 +181,9 @@ return [
         ],
     ],
     'laravel' => [
-        //
+        LaravelDispatchShortcutCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
     ],
 ];

--- a/src/Commands/Extension/Laravel/LaravelDispatchShortcutCommand.php
+++ b/src/Commands/Extension/Laravel/LaravelDispatchShortcutCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Extension\Laravel;
+
+use Vix\Syntra\Commands\Rector\Laravel\DispatchShortcutRector;
+use Vix\Syntra\Commands\RectorRunnerCommand;
+
+class LaravelDispatchShortcutCommand extends RectorRunnerCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('laravel:dispatch-shortcut')
+            ->setDescription('Rewrites dispatch(new SomeJob($args)) to SomeJob::dispatch($args)')
+            ->setHelp('Usage: vendor/bin/syntra laravel:dispatch-shortcut');
+    }
+
+    protected function getRectorRules(): string
+    {
+        return DispatchShortcutRector::class;
+    }
+}

--- a/src/Commands/Rector/Laravel/DispatchShortcutRector.php
+++ b/src/Commands/Rector/Laravel/DispatchShortcutRector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Rector\Laravel;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class DispatchShortcutRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rewrites dispatch(new SomeJob($args)) to SomeJob::dispatch($args)',
+            []
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isName($node, 'dispatch')) {
+            return null;
+        }
+
+        if (count($node->args) !== 1) {
+            return null;
+        }
+
+        $arg = $node->args[0]->value;
+        if (!$arg instanceof New_ || !$arg->class instanceof Name) {
+            return null;
+        }
+
+        return new StaticCall($arg->class, 'dispatch', $arg->args);
+    }
+}

--- a/tests/Commands/LaravelDispatchShortcutCommandTest.php
+++ b/tests/Commands/LaravelDispatchShortcutCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\Extension\Laravel\LaravelDispatchShortcutCommand;
+use Vix\Syntra\DTO\ProcessResult;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Utils\RectorCommandExecutor;
+
+class LaravelDispatchShortcutCommandTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($this->dir);
+        File::clearCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $file = "$this->dir/sample.php";
+        if (file_exists($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->dir)) {
+            rmdir($this->dir);
+        }
+    }
+
+    private function createFile(string $content): void
+    {
+        file_put_contents("$this->dir/sample.php", $content);
+    }
+
+    private function runCommand(array $options = []): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot($this->dir);
+
+        /** @var LaravelDispatchShortcutCommand $command */
+        $command = $app->find('laravel:dispatch-shortcut');
+
+        $ref = new ReflectionClass(LaravelDispatchShortcutCommand::class);
+        $prop = $ref->getProperty('rectorExecutor');
+        $prop->setAccessible(true);
+        $prop->setValue($command, new class extends RectorCommandExecutor {
+            public function executeRule(string $rectorClass, array $additionalArgs = [], ?callable $outputCallback = null): ProcessResult
+            {
+                $dryRun = in_array('--dry-run', $additionalArgs, true);
+                $files = File::collectFiles(Config::getProjectRoot());
+
+                foreach ($files as $file) {
+                    $old = file_get_contents($file);
+                    $new = preg_replace('/dispatch\s*\(\s*new\s+([\\\\\w]+)\(([^)]*)\)\s*\)/', '$1::dispatch($2)', $old);
+                    if ($new !== null && !$dryRun) {
+                        File::writeChanges($file, $old, $new);
+                    }
+                    if ($outputCallback) {
+                        $outputCallback();
+                    }
+                }
+
+                return new ProcessResult(0, '', '');
+            }
+        });
+
+        $tester = new CommandTester($command);
+        $input = array_merge(['path' => $this->dir], $options);
+        $tester->execute($input);
+    }
+
+    public function testReplacesDispatchCall(): void
+    {
+        $content = "<?php\ndispatch(new MyJob('a'));";
+        $expected = "<?php\nMyJob::dispatch('a');";
+        $this->createFile($content);
+
+        $this->runCommand();
+
+        $result = file_get_contents("$this->dir/sample.php");
+        $this->assertSame($expected, trim($result));
+    }
+
+    public function testDryRunDoesNotModifyFile(): void
+    {
+        $content = "<?php\ndispatch(new MyJob('a'));";
+        $this->createFile($content);
+
+        $this->runCommand(['--dry-run' => true]);
+
+        $result = file_get_contents("$this->dir/sample.php");
+        $this->assertSame(trim($content), trim($result));
+    }
+}


### PR DESCRIPTION
## Summary
- add Rector rule for `dispatch(new Job())` replacement
- support `laravel:dispatch-shortcut` command
- register the new command
- document Laravel integration
- test Laravel command behavior

## Testing
- `composer dump-autoload`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686ad23cc8908322985fd155405fb84f