### PR TITLE
Add danger level warning

### DIFF
--- a/src/Commands/SyntraRefactorCommand.php
+++ b/src/Commands/SyntraRefactorCommand.php
@@ -7,7 +7,6 @@ namespace Vix\Syntra\Commands;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Traits\HasDangerLevel;
 
@@ -31,13 +30,6 @@ abstract class SyntraRefactorCommand extends SyntraCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if ($this->getDangerLevel() !== DangerLevel::LOW) {
-            $output->writeln(sprintf(
-                '<comment>Warning: this command is marked as %s and may be unsafe.</comment>',
-                $this->getDangerLevel()->value,
-            ));
-        }
-
         if (!$this->askDangerConfirmation($input, $output)) {
             return Command::FAILURE;
         }

--- a/src/Commands/SyntraRefactorCommand.php
+++ b/src/Commands/SyntraRefactorCommand.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Commands;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Traits\HasDangerLevel;
 
@@ -25,5 +27,21 @@ abstract class SyntraRefactorCommand extends SyntraCommand
         $this->force = (bool) $input->getOption('force');
 
         parent::initialize($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($this->getDangerLevel() !== DangerLevel::LOW) {
+            $output->writeln(sprintf(
+                '<comment>Warning: this command is marked as %s and may be unsafe.</comment>',
+                $this->getDangerLevel()->value,
+            ));
+        }
+
+        if (!$this->askDangerConfirmation($input, $output)) {
+            return Command::FAILURE;
+        }
+
+        return parent::execute($input, $output);
     }
 }

--- a/src/Traits/HasDangerLevel.php
+++ b/src/Traits/HasDangerLevel.php
@@ -50,6 +50,11 @@ trait HasDangerLevel
             /** @var QuestionHelper $helper */
             $helper = $this->getHelper('question');
 
+            $output->writeln(sprintf(
+                '<comment>Warning: the danger level of this command is marked as %s and it may be unsafe.</comment>',
+                $this->getDangerLevel()->value,
+            ));
+
             $question = new ConfirmationQuestion(
                 '<fg=yellow>Are you sure you want to execute this command? (y/N): </>',
                 false,

--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -35,8 +35,8 @@ class DangerLevelWarningTest extends TestCase
 
         $app->add($command);
         $tester = new CommandTester($command);
-        $tester->execute(['--force' => true]);
+        $tester->execute([]);
 
-        $this->assertStringContainsString('Warning: this command is marked as HIGH', $tester->getDisplay());
+        $this->assertStringContainsString('Warning: the danger level of this command is marked as', $tester->getDisplay());
     }
 }

--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Command\Command;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\SyntraRefactorCommand;
+use Vix\Syntra\Enums\DangerLevel;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class DangerLevelWarningTest extends TestCase
+{
+    public function testWarningShownForHighDanger(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+
+        $command = new class extends SyntraRefactorCommand {
+            protected function configure(): void
+            {
+                parent::configure();
+                $this->setName('dummy:danger')
+                    ->setDescription('desc')
+                    ->setDangerLevel(DangerLevel::HIGH);
+            }
+
+            public function perform(): int
+            {
+                return Command::SUCCESS;
+            }
+        };
+
+        $app->add($command);
+        $tester = new CommandTester($command);
+        $tester->execute(['--force' => true]);
+
+        $this->assertStringContainsString('Warning: this command is marked as HIGH', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- warn when running a command marked as HIGH or MEDIUM danger level
- test warning logic with a custom SyntraRefactorCommand

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`