### PR TITLE
Add CI-friendly flags and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ All commands support these standard options (with an optional `[path]` argument 
 -   `--force` / `-f`: Force execution, ignore warnings (refactor commands only)
 -   `--no-progress`: Disable progress output
 -   `--no-cache`: Disable file caching (useful for temporary directories)
+-   `--fail-on-warning`: Return exit code 1 if warnings were found
+-   `--ci`: CI mode, implies `--no-progress` and `--fail-on-warning`
 -   `--help` / `-h`: Display help for the command
 -   `--quiet` / `-q`: Only show errors
 -   `--verbose` / `-v/-vv/-vvv`: Increase verbosity level
@@ -209,6 +211,9 @@ Add to your CI pipeline:
   run: |
       vendor/bin/syntra health:project
       vendor/bin/syntra analyze:find-debug-calls
+
+# Fail the pipeline on warnings
+      vendor/bin/syntra health:composer --ci
 ```
 
 ### Running Tests

--- a/src/Commands/Health/ComposerCheckCommand.php
+++ b/src/Commands/Health/ComposerCheckCommand.php
@@ -53,6 +53,6 @@ class ComposerCheckCommand extends SyntraCommand implements HealthCheckCommandIn
 
         $result = $this->runCheck();
 
-        return $this->handleResult($result, 'Composer check completed.');
+        return $this->handleResult($result, 'Composer check completed.', $this->failOnWarning);
     }
 }

--- a/src/Commands/Health/PhpStanCheckCommand.php
+++ b/src/Commands/Health/PhpStanCheckCommand.php
@@ -80,6 +80,6 @@ class PhpStanCheckCommand extends SyntraCommand implements HealthCheckCommandInt
             return self::FAILURE;
         }
 
-        return $this->handleResult($result, 'PHPStan analysis completed.');
+        return $this->handleResult($result, 'PHPStan analysis completed.', $this->failOnWarning);
     }
 }

--- a/src/Commands/Health/PhpUnitCheckCommand.php
+++ b/src/Commands/Health/PhpUnitCheckCommand.php
@@ -59,6 +59,6 @@ class PhpUnitCheckCommand extends SyntraCommand implements HealthCheckCommandInt
             return self::FAILURE;
         }
 
-        return $this->handleResult($result, 'PHPUnit tests finished.');
+        return $this->handleResult($result, 'PHPUnit tests finished.', $this->failOnWarning);
     }
 }

--- a/src/Commands/Health/SecurityCheckCommand.php
+++ b/src/Commands/Health/SecurityCheckCommand.php
@@ -60,6 +60,6 @@ class SecurityCheckCommand extends SyntraCommand implements HealthCheckCommandIn
 
         $result = $this->runCheck();
 
-        return $this->handleResult($result, 'Composer security audit completed.');
+        return $this->handleResult($result, 'Composer security audit completed.', $this->failOnWarning);
     }
 }

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -25,6 +25,8 @@ abstract class SyntraCommand extends Command
     protected bool $dryRun = false;
     protected bool $noProgress = false;
     protected bool $noCache = false;
+    protected bool $failOnWarning = false;
+    protected bool $ciMode = false;
 
     protected ProgressIndicatorInterface $progressIndicator;
 
@@ -43,7 +45,9 @@ abstract class SyntraCommand extends Command
             ->addArgument('path', InputArgument::OPTIONAL, 'Root path of the project', Config::getProjectRoot())
             ->addOption('dry-run', 'd', InputOption::VALUE_NONE, 'Do not apply changes, only show what would be done')
             ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disable progress output')
-            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Disable file caching');
+            ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Disable file caching')
+            ->addOption('fail-on-warning', null, InputOption::VALUE_NONE, 'Return exit code 1 if warnings were found')
+            ->addOption('ci', null, InputOption::VALUE_NONE, 'CI mode (implies --no-progress and --fail-on-warning)');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
@@ -54,6 +58,13 @@ abstract class SyntraCommand extends Command
         $this->dryRun = (bool) $input->getOption('dry-run');
         $this->noProgress = (bool) $input->getOption('no-progress');
         $this->noCache = (bool) $input->getOption('no-cache');
+        $this->failOnWarning = (bool) $input->getOption('fail-on-warning');
+        $this->ciMode = (bool) $input->getOption('ci') || getenv('CI') !== false;
+
+        if ($this->ciMode) {
+            $this->noProgress = true;
+            $this->failOnWarning = true;
+        }
 
         FileHelper::setCacheEnabled(!$this->noCache);
 

--- a/src/Traits/HandlesResultTrait.php
+++ b/src/Traits/HandlesResultTrait.php
@@ -13,7 +13,7 @@ use Vix\Syntra\Enums\CommandStatus;
  */
 trait HandlesResultTrait
 {
-    protected function handleResult(CommandResult $result, string $successMessage): int
+    protected function handleResult(CommandResult $result, string $successMessage, bool $failOnWarning = false): int
     {
         if ($result->status === CommandStatus::OK) {
             $this->output->success($successMessage);
@@ -30,6 +30,10 @@ trait HandlesResultTrait
             $this->output->writeln('  - ' . $msg);
         }
 
-        return $result->status === CommandStatus::WARNING ? Command::SUCCESS : Command::FAILURE;
+        if ($result->status === CommandStatus::WARNING && !$failOnWarning) {
+            return Command::SUCCESS;
+        }
+
+        return $result->status === CommandStatus::OK ? Command::SUCCESS : Command::FAILURE;
     }
 }

--- a/tests/Commands/FailOnWarningTest.php
+++ b/tests/Commands/FailOnWarningTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Command\Command;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\DTO\CommandResult;
+use Vix\Syntra\Traits\HandlesResultTrait;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class FailOnWarningTest extends TestCase
+{
+    private function makeCommand(): SyntraCommand
+    {
+        return new class extends SyntraCommand {
+            use HandlesResultTrait;
+
+            protected function configure(): void
+            {
+                parent::configure();
+                $this->setName('dummy:warn');
+            }
+
+            public function perform(): int
+            {
+                $result = CommandResult::warning(['warn']);
+                return $this->handleResult($result, 'done', $this->failOnWarning);
+            }
+        };
+    }
+
+    public function testFailOnWarningOption(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+
+        $command = $this->makeCommand();
+        $app->add($command);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--fail-on-warning' => true]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+    }
+
+    public function testCiModeFailsOnWarning(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+
+        $command = $this->makeCommand();
+        $app->add($command);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--ci' => true]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- add `--fail-on-warning` and `--ci` options to `SyntraCommand`
- make progress and warnings behave predictably in CI
- document the new options in README
- update health commands to honour the new flag
- add tests for failing on warnings

## Testing
- `vendor/bin/phpunit --stop-on-failure`