### PR TITLE
Add editorconfig generation option

### DIFF
--- a/config.php
+++ b/config.php
@@ -19,6 +19,7 @@ use Vix\Syntra\Commands\Extension\Yii\YiiUserFindoneToIdentityCommand;
 use Vix\Syntra\Commands\General\GenerateCommandCommand;
 use Vix\Syntra\Commands\General\GenerateDocsCommand;
 use Vix\Syntra\Commands\Health\ComposerCheckCommand;
+use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\Commands\Health\PhpStanCheckCommand;
 use Vix\Syntra\Commands\Health\PhpUnitCheckCommand;
 use Vix\Syntra\Commands\Health\ProjectCheckCommand;
@@ -87,6 +88,10 @@ return [
     ],
     'health' => [
         ComposerCheckCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
+        EditorConfigCheckCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
         ],

--- a/src/Commands/Health/EditorConfigCheckCommand.php
+++ b/src/Commands/Health/EditorConfigCheckCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Health;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Vix\Syntra\Commands\Health\HealthCheckCommandInterface;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\DTO\CommandResult;
+use Vix\Syntra\Enums\CommandStatus;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Traits\HandlesResultTrait;
+
+class EditorConfigCheckCommand extends SyntraCommand implements HealthCheckCommandInterface
+{
+    use HandlesResultTrait;
+
+    private const DEFAULT_CONFIG = <<<'CFG'
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[docker-compose.yml]
+indent_size = 2
+
+[*.php]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+CFG;
+
+    protected function configure(): void
+    {
+        parent::configure();
+        $this->setName('health:editorconfig')
+            ->setDescription('Checks for the existence of a .editorconfig file.')
+            ->addOption('generate', 'g', InputOption::VALUE_NONE, 'Generate a default .editorconfig file if missing');
+    }
+
+    public function runCheck(): CommandResult
+    {
+        $path = Config::getProjectRoot() . '/.editorconfig';
+
+        if (is_file($path)) {
+            return CommandResult::ok(['.editorconfig file exists.']);
+        }
+
+        return CommandResult::warning([
+            '.editorconfig file not found. Use --generate to create a default one.',
+        ]);
+    }
+
+    public function perform(): int
+    {
+        $this->output->section('Checking for .editorconfig...');
+
+        $result = $this->runCheck();
+        if ($result->status === CommandStatus::WARNING && $this->input->getOption('generate')) {
+            $path = Config::getProjectRoot() . '/.editorconfig';
+            file_put_contents($path, self::DEFAULT_CONFIG . "\n");
+            $this->output->success('.editorconfig file generated.');
+            return Command::SUCCESS;
+        }
+
+        return $this->handleResult($result, '.editorconfig check completed.');
+    }
+}

--- a/src/Commands/Health/ProjectCheckCommand.php
+++ b/src/Commands/Health/ProjectCheckCommand.php
@@ -7,6 +7,7 @@ namespace Vix\Syntra\Commands\Health;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Vix\Syntra\Commands\Health\ComposerCheckCommand;
+use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\Commands\Health\PhpStanCheckCommand;
 use Vix\Syntra\Commands\Health\PhpUnitCheckCommand;
 use Vix\Syntra\Commands\SyntraCommand;
@@ -31,6 +32,7 @@ class ProjectCheckCommand extends SyntraCommand
         $this->output->section('Starting project health check...');
 
         $checks = [
+            ['name' => 'EditorConfig', 'class' => EditorConfigCheckCommand::class],
             ['name' => 'Composer', 'class' => ComposerCheckCommand::class],
             ['name' => 'PHPStan', 'class' => PhpStanCheckCommand::class],
             ['name' => 'PHPUnit', 'class' => PhpUnitCheckCommand::class],

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
+use Vix\Syntra\DI\Container;
+use Vix\Syntra\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Enums\CommandStatus;
+use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class EditorConfigCheckCommandTest extends TestCase
+{
+    private function makeCommand(string $root): EditorConfigCheckCommand
+    {
+        $container = new Container();
+        $container->instance(ConfigLoader::class, new ConfigLoader($root));
+        Facade::setContainer($container);
+
+        return new EditorConfigCheckCommand();
+    }
+
+    public function testOkWhenFileExists(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents($dir . '/.editorconfig', "root = true\n");
+
+        $cmd = $this->makeCommand($dir);
+        $result = $cmd->runCheck();
+
+        $this->assertSame(CommandStatus::OK, $result->status);
+
+        unlink($dir . '/.editorconfig');
+        rmdir($dir);
+    }
+
+    public function testWarningWhenFileMissing(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+
+        $cmd = $this->makeCommand($dir);
+        $result = $cmd->runCheck();
+
+        $this->assertSame(CommandStatus::WARNING, $result->status);
+        $this->assertStringContainsString('file not found', implode('\n', $result->messages));
+
+        rmdir($dir);
+    }
+
+    public function testGenerateOptionCreatesFile(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+
+        $command = $app->find('health:editorconfig');
+        $tester = new CommandTester($command);
+        $tester->execute(['path' => $dir, '--generate' => true]);
+
+        $this->assertFileExists("$dir/.editorconfig");
+        $ref = new \ReflectionClass(EditorConfigCheckCommand::class);
+        $expected = trim((string) $ref->getConstant('DEFAULT_CONFIG'));
+        $actual = trim((string) file_get_contents("$dir/.editorconfig"));
+        $this->assertSame($expected, $actual);
+
+        unlink("$dir/.editorconfig");
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary
- add default editorconfig template to `EditorConfigCheckCommand`
- allow generating a `.editorconfig` file with `--generate`
- test the new generation option

## Testing
- `vendor/bin/phpunit tests/Commands/EditorConfigCheckCommandTest.php --filter EditorConfigCheckCommandTest --testdox`
- `vendor/bin/phpunit --testdox`


------
https://chatgpt.com/codex/tasks/task_e_686aede1b8908322b2a0177e9d166bec