### PR TITLE
Add default PHPStan config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ return [
 ];
 ```
 
+The PHPStan health check reads from `config/phpstan.neon` by default, so tweak that file to customize analysis settings.
+
 ## 💡 Tips & Best Practices
 
 ### Safety First

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -1,0 +1,9 @@
+includes:
+    - ../vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: 5
+    paths:
+        - ../src
+        - ../tests


### PR DESCRIPTION
## Summary
- set up a starter `config/phpstan.neon` with level, paths, and common extensions
- mention the default PHPStan config path in the README

## Testing
- `composer install`
- `vendor/bin/phpunit`