### PR TITLE
Introduce ProgressIndicatorType enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 -   **Cache Reset**: Call `FileHelper::clearCache()` to manually reset cached file lists when working with temporary directories or tests.
 -   **No-Cache Option**: Use `--no-cache` to disable caching for a single command run.
 -   **Facades**: Convenient static access to common services.
+-   **Progress Indicators**: Choose between spinner, progress bar, bouncing, or none via the `ProgressIndicatorType` enum.
 
 ## 📦 Installation
 

--- a/src/Commands/Analyze/FindBadPracticesCommand.php
+++ b/src/Commands/Analyze/FindBadPracticesCommand.php
@@ -14,6 +14,7 @@ use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 use Vix\Syntra\NodeVisitors\AssignmentInConditionVisitor;
 use Vix\Syntra\NodeVisitors\NestedTernaryVisitor;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\Traits\ContainerAwareTrait;
 
@@ -21,7 +22,7 @@ class FindBadPracticesCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
 
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/Analyze/FindDebugCallsCommand.php
+++ b/src/Commands/Analyze/FindDebugCallsCommand.php
@@ -8,11 +8,12 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 
 class FindDebugCallsCommand extends SyntraCommand
 {
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected static array $DEBUG_FUNCTIONS = [
         'var_dump',

--- a/src/Commands/Analyze/FindLongMethodsCommand.php
+++ b/src/Commands/Analyze/FindLongMethodsCommand.php
@@ -14,6 +14,7 @@ use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 use Vix\Syntra\NodeVisitors\LongMethodVisitor;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\Traits\ContainerAwareTrait;
 
@@ -21,7 +22,7 @@ class FindLongMethodsCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
 
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/Analyze/FindTodosCommand.php
+++ b/src/Commands/Analyze/FindTodosCommand.php
@@ -8,11 +8,12 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 
 class FindTodosCommand extends SyntraCommand
 {
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected static array $TAGS = [
         'TODO',

--- a/src/Commands/General/GenerateDocsCommand.php
+++ b/src/Commands/General/GenerateDocsCommand.php
@@ -14,6 +14,7 @@ use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 use Vix\Syntra\NodeVisitors\DocsVisitor;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\Traits\ContainerAwareTrait;
 use Vix\Syntra\Utils\ProjectDetector;
@@ -22,7 +23,7 @@ class GenerateDocsCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
 
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/Refactor/DocblockRefactorer.php
+++ b/src/Commands/Refactor/DocblockRefactorer.php
@@ -10,12 +10,13 @@ use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\Utils\StubHelper;
 
 class DocblockRefactorer extends SyntraRefactorCommand
 {
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/Refactor/ImportRefactorer.php
+++ b/src/Commands/Refactor/ImportRefactorer.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 
 /**
@@ -18,7 +19,7 @@ use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
  */
 class ImportRefactorer extends SyntraRefactorCommand
 {
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/Refactor/VarCommentsRefactorer.php
+++ b/src/Commands/Refactor/VarCommentsRefactorer.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 
 /**
@@ -18,7 +19,7 @@ use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
  */
 class VarCommentsRefactorer extends SyntraRefactorCommand
 {
-    protected string $progressType = ProgressIndicatorFactory::TYPE_PROGRESS_BAR;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
     {

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 use Vix\Syntra\Traits\HasStyledOutput;
@@ -28,7 +29,7 @@ abstract class SyntraCommand extends Command
 
     protected ProgressIndicatorInterface $progressIndicator;
 
-    protected string $progressType = ProgressIndicatorFactory::TYPE_SPINNER;
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::SPINNER;
 
     protected int $progressMax = 0;
 
@@ -72,7 +73,7 @@ abstract class SyntraCommand extends Command
 
     protected function startProgress(): void
     {
-        $type = $this->noProgress ? ProgressIndicatorFactory::TYPE_NONE : $this->progressType;
+        $type = $this->noProgress ? ProgressIndicatorType::NONE : $this->progressType;
 
         $this->progressIndicator = ProgressIndicatorFactory::create(
             $type,

--- a/src/Enums/ProgressIndicatorType.php
+++ b/src/Enums/ProgressIndicatorType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Enums;
+
+enum ProgressIndicatorType: string
+{
+    case SPINNER = 'spinner';
+    case PROGRESS_BAR = 'progress_bar';
+    case BOUNCING = 'bouncing';
+    case NONE = 'none';
+}

--- a/src/ProgressIndicators/ProgressIndicatorFactory.php
+++ b/src/ProgressIndicators/ProgressIndicatorFactory.php
@@ -5,27 +5,22 @@ declare(strict_types=1);
 namespace Vix\Syntra\ProgressIndicators;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\ProgressIndicators\NullProgressIndicator;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 
 class ProgressIndicatorFactory
 {
-    public const TYPE_SPINNER = 'spinner';
-    public const TYPE_PROGRESS_BAR = 'progress_bar';
-    public const TYPE_BOUNCING = 'bouncing';
-    public const TYPE_NONE = 'none';
-
     public static function create(
-        string $type,
+        ProgressIndicatorType $type,
         SymfonyStyle $output,
         int $maxSteps = 0
     ): ProgressIndicatorInterface {
         return match ($type) {
-            self::TYPE_PROGRESS_BAR => new ProgressBarIndicator($output, $maxSteps),
-            self::TYPE_SPINNER => new SpinnerIndicator($output),
-            self::TYPE_BOUNCING => new BouncingIndicator($output),
-            self::TYPE_NONE => new NullProgressIndicator(),
-            default => new SpinnerIndicator($output),
+            ProgressIndicatorType::PROGRESS_BAR => new ProgressBarIndicator($output, $maxSteps),
+            ProgressIndicatorType::SPINNER => new SpinnerIndicator($output),
+            ProgressIndicatorType::BOUNCING => new BouncingIndicator($output),
+            ProgressIndicatorType::NONE => new NullProgressIndicator(),
         };
     }
 }


### PR DESCRIPTION
## Summary
- add `ProgressIndicatorType` enum for spinner, progress bar, bouncing and none
- refactor progress indicator factory to take the enum
- update command classes to use the enum instead of string constants
- document progress indicator options in README

## Testing
- `vendor/bin/phpunit`