### PR TITLE
Introduce CommandGroup enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,19 @@ All commands support these standard options (with an optional `[path]` argument 
 
 Configuration is defined in PHP via `config.php`, allowing you to enable/disable commands or set options per tool. Example:
 
+The default group names are provided as enum cases in `Vix\Syntra\Enums\CommandGroup`.
+
 ```php
+use Vix\Syntra\Enums\CommandGroup;
+
 return [
-    'refactor' => [
+    CommandGroup::REFACTOR->value => [
         PhpCsFixerRefactorer::class => [
             'enabled' => true,
             'config' => __DIR__ . '/config/php_cs_fixer.php',
         ],
     ],
-    'yii' => [
+    CommandGroup::YII->value => [
         YiiFindShortcutsCommand::class => true,
     ],
 ];

--- a/config.php
+++ b/config.php
@@ -28,6 +28,7 @@ use Vix\Syntra\Commands\Refactor\ImportRefactorer;
 use Vix\Syntra\Commands\Refactor\PhpCsFixerRefactorer;
 use Vix\Syntra\Commands\Refactor\RectorRefactorer;
 use Vix\Syntra\Commands\Refactor\VarCommentsRefactorer;
+use Vix\Syntra\Enums\CommandGroup;
 
 /**
  * Syntra Configuration
@@ -60,7 +61,7 @@ return [
     ],
 
     // Command configurations
-    'refactor' => [
+    CommandGroup::REFACTOR->value => [
         DocblockRefactorer::class => [
             'enabled' => true,
             'web_enabled' => true,
@@ -85,7 +86,7 @@ return [
             'commands_config' => PACKAGE_ROOT . '/config/rector_only_custom.php',
         ],
     ],
-    'health' => [
+    CommandGroup::HEALTH->value => [
         ComposerCheckCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
@@ -109,7 +110,7 @@ return [
             'web_enabled' => true,
         ],
     ],
-    'analyze' => [
+    CommandGroup::ANALYZE->value => [
         FindTodosCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
@@ -127,7 +128,7 @@ return [
             'web_enabled' => true,
         ],
     ],
-    'general' => [
+    CommandGroup::GENERAL->value => [
         GenerateCommandCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
@@ -137,7 +138,7 @@ return [
             'web_enabled' => true,
         ],
     ],
-    'yii' => [
+    CommandGroup::YII->value => [
         YiiAllCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
@@ -179,7 +180,7 @@ return [
             'web_enabled' => true,
         ],
     ],
-    'laravel' => [
+    CommandGroup::LARAVEL->value => [
         //
     ],
 ];

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,6 +11,9 @@ Syntra uses a single configuration file (`config.php`) that controls:
 -   **Command Settings**: Tool-specific configurations (like config file paths)
 -   **Security Settings**: Web interface security controls
 
+Default group names are provided as enum cases in `Vix\\Syntra\\Enums\\CommandGroup` to
+avoid typos when referencing configuration sections.
+
 ## Configuration Structure
 
 ```php
@@ -72,14 +75,16 @@ Each command can be configured using either:
 ### Basic Configuration
 
 ```php
+use Vix\Syntra\Enums\CommandGroup;
+
 return [
     'web' => ['enabled' => true],
 
-    'analyze' => [
+    CommandGroup::ANALYZE->value => [
         FindTodosCommand::class => true, // Enabled for both console and web
     ],
 
-    'health' => [
+    CommandGroup::HEALTH->value => [
         ProjectCheckCommand::class => [
             'enabled' => true,     // Console access
             'web_enabled' => true, // Web access
@@ -142,15 +147,15 @@ return [
 
 ### Core Commands
 
--   **`analyze`**: Code analysis commands (safe, read-only)
--   **`health`**: Project health checks (safe, read-only)
--   **`refactor`**: Code modification commands (⚠️ **use with caution**)
--   **`general`**: Utility commands
+-   **`analyze`** (`CommandGroup::ANALYZE`): Code analysis commands (safe, read-only)
+-   **`health`** (`CommandGroup::HEALTH`): Project health checks (safe, read-only)
+-   **`refactor`** (`CommandGroup::REFACTOR`): Code modification commands (⚠️ **use with caution**)
+-   **`general`** (`CommandGroup::GENERAL`): Utility commands
 
 ### Extension Commands
 
--   **`yii`**: Yii framework-specific commands
--   **`laravel`**: Laravel framework-specific commands (planned)
+-   **`yii`** (`CommandGroup::YII`): Yii framework-specific commands
+-   **`laravel`** (`CommandGroup::LARAVEL`): Laravel framework-specific commands (planned)
 
 ## Security Considerations
 

--- a/src/Commands/Health/PhpStanCheckCommand.php
+++ b/src/Commands/Health/PhpStanCheckCommand.php
@@ -7,6 +7,7 @@ namespace Vix\Syntra\Commands\Health;
 use Vix\Syntra\Commands\Health\HealthCheckCommandInterface;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DTO\CommandResult;
+use Vix\Syntra\Enums\CommandGroup;
 use Vix\Syntra\Exceptions\CommandException;
 use Vix\Syntra\Exceptions\MissingBinaryException;
 use Vix\Syntra\Facades\Config;
@@ -34,10 +35,10 @@ class PhpStanCheckCommand extends SyntraCommand implements HealthCheckCommandInt
 
         $args = [
             'analyse',
-            '--level=' . (int) Config::getCommandOption('health', self::class, 'level', 0),
+            '--level=' . (int) Config::getCommandOption(CommandGroup::HEALTH->value, self::class, 'level', 0),
             '--error-format=json',
             '--no-progress',
-            '--configuration=' . Config::getCommandOption('health', self::class, 'config', 'phpstan.neon'),
+            '--configuration=' . Config::getCommandOption(CommandGroup::HEALTH->value, self::class, 'config', 'phpstan.neon'),
             Config::getProjectRoot(),
         ];
 

--- a/src/Commands/Refactor/PhpCsFixerRefactorer.php
+++ b/src/Commands/Refactor/PhpCsFixerRefactorer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands\Refactor;
 
 use Vix\Syntra\Commands\SyntraRefactorCommand;
+use Vix\Syntra\Enums\CommandGroup;
 use Vix\Syntra\Exceptions\MissingBinaryException;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\Process;
@@ -34,7 +35,7 @@ class PhpCsFixerRefactorer extends SyntraRefactorCommand
             $this->advanceProgress();
         };
 
-        $config = Config::getCommandOption('refactor', self::class, 'config');
+        $config = Config::getCommandOption(CommandGroup::REFACTOR->value, self::class, 'config');
 
         $result = Process::run($binary, [
             'fix',

--- a/src/Commands/Refactor/RectorRefactorer.php
+++ b/src/Commands/Refactor/RectorRefactorer.php
@@ -6,6 +6,7 @@ namespace Vix\Syntra\Commands\Refactor;
 
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
+use Vix\Syntra\Enums\CommandGroup;
 use Vix\Syntra\Exceptions\MissingBinaryException;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\Process;
@@ -39,7 +40,7 @@ class RectorRefactorer extends SyntraRefactorCommand
         $result = Process::run($binary, [
             'process',
             Config::getProjectRoot(),
-            "--config=" . Config::getCommandOption('refactor', self::class, 'config'),
+            "--config=" . Config::getCommandOption(CommandGroup::REFACTOR->value, self::class, 'config'),
             "--clear-cache",
         ], callback: $outputCallback);
 

--- a/src/Enums/CommandGroup.php
+++ b/src/Enums/CommandGroup.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Enums;
+
+/**
+ * Defines the default command groups used by Syntra.
+ */
+enum CommandGroup: string
+{
+    case REFACTOR = 'refactor';
+    case HEALTH = 'health';
+    case ANALYZE = 'analyze';
+    case GENERAL = 'general';
+    case YII = 'yii';
+    case LARAVEL = 'laravel';
+}

--- a/src/Utils/ConfigLoader.php
+++ b/src/Utils/ConfigLoader.php
@@ -4,9 +4,21 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Utils;
 
+use Vix\Syntra\Enums\CommandGroup;
+
 class ConfigLoader
 {
-    private array $coreGroups = ['refactor', 'health', 'analyze', 'general'];
+    /**
+     * List of built-in command groups.
+     *
+     * @var string[]
+     */
+    private array $coreGroups = [
+        CommandGroup::REFACTOR->value,
+        CommandGroup::HEALTH->value,
+        CommandGroup::ANALYZE->value,
+        CommandGroup::GENERAL->value,
+    ];
 
     private ?string $projectRoot = null;
 

--- a/src/Utils/RectorCommandExecutor.php
+++ b/src/Utils/RectorCommandExecutor.php
@@ -9,6 +9,7 @@ use Vix\Syntra\DTO\ProcessResult;
 use Vix\Syntra\Exceptions\MissingBinaryException;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\Process;
+use Vix\Syntra\Enums\CommandGroup;
 
 /**
  * Utility class for executing Rector commands with specific rules
@@ -117,7 +118,7 @@ class RectorCommandExecutor
     private function getRectorConfig(): string
     {
         return Config::getCommandOption(
-            'refactor',
+            CommandGroup::REFACTOR->value,
             RectorRefactorer::class,
             'commands_config'
         );


### PR DESCRIPTION
## Summary
- convert `CommandGroup` constants to an enum
- use new enum case values in `config.php` and configuration loader
- update refactor and health commands to reference the enum
- document enum usage in README and configuration guide

## Testing
- `vendor/bin/phpunit`