### PR TITLE
Add config path helper

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,6 +7,11 @@ if (!defined('PACKAGE_ROOT')) {
     define('PACKAGE_ROOT', __DIR__);
 }
 
+// Define configuration directory
+if (!defined('CONFIG_DIR')) {
+    define('CONFIG_DIR', PACKAGE_ROOT . '/config');
+}
+
 // Load helper functions
 require_once __DIR__ . '/helpers.php';
 

--- a/config.php
+++ b/config.php
@@ -80,7 +80,7 @@ return [
         PhpCsFixerRefactorer::class => [
             'enabled' => true,
             'web_enabled' => true,
-            'config' => PACKAGE_ROOT . '/config/php_cs_fixer.php',
+            'config' => config_path('php_cs_fixer.php'),
         ],
         VarCommentsRefactorer::class => [
             'enabled' => true,
@@ -89,8 +89,8 @@ return [
         RectorRefactorer::class => [
             'enabled' => true,
             'web_enabled' => true,
-            'config' => PACKAGE_ROOT . '/config/rector.php',
-            'commands_config' => PACKAGE_ROOT . '/config/rector_only_custom.php',
+            'config' => config_path('rector.php'),
+            'commands_config' => config_path('rector_only_custom.php'),
         ],
     ],
     CommandGroup::HEALTH->value => [
@@ -105,7 +105,7 @@ return [
         PhpStanCheckCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
-            'config' => PACKAGE_ROOT . '/config/phpstan.neon',
+            'config' => config_path('phpstan.neon'),
             'level' => 5,
         ],
         PhpUnitCheckCommand::class => [

--- a/helpers.php
+++ b/helpers.php
@@ -28,6 +28,16 @@ if (!function_exists('find_composer_autoload')) {
     }
 }
 
+if (!function_exists('config_path')) {
+    /**
+     * Get path inside config directory
+     */
+    function config_path(string $file = ''): string
+    {
+        return $file === '' ? CONFIG_DIR : CONFIG_DIR . '/' . ltrim($file, '/');
+    }
+}
+
 if (!function_exists('find_composer_bin')) {
     /**
      * Find composer binary


### PR DESCRIPTION
## Summary
- add `CONFIG_DIR` constant for shared config path
- add `config_path()` helper
- update configuration to use the new helper

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --stop-on-failure`