### PR TITLE
Add framework option to refactor:all

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ All commands support these standard options (with an optional `[path]` argument 
 | `refactor:var-comments` | Standardizes @var comments to `/** @var Type $var */`             | 🟢 LOW       | `[path]`, `--dry-run`, `--no-cache`, `--force`                                     |
 | `refactor:docblocks`    | Adds a file-level PHPDoc block and class PHPDoc blocks if missing | 🟡 MEDIUM    | `[path]`, `--dry-run`, `--no-cache`, `--force`, `--author`, `--link`, `--category` |
 | `refactor:rector`       | Runs Rector for automated refactoring                             | 🔴 HIGH      | `[path]`, `--dry-run`, `--no-cache`, `--force`                                     |
-| `refactor:all`          | Runs all enabled refactor commands sequentially    | 🔴 HIGH      | `[path]`, `--dry-run`, `--no-cache`, `--force`                                  |
+| `refactor:all`          | Runs all enabled refactor commands sequentially    | 🔴 HIGH      | `[path]`, `--dry-run`, `--no-cache`, `--force`, `--framework`                                  |
 
 ### 🧠 General
 
@@ -143,6 +143,13 @@ All commands support these standard options (with an optional `[path]` argument 
 | `yii:check-translations`       | Checks Yii::t translations: finds missing and unused keys across all categories                      | N/A          | `[path]`, `--dry-run`, `--lang`     |
 | `yii:convert-access-chain`     | Replaces `user->identity->hasAccessChain/hasNoAccessChain` with `user->canAny/cannotAny`             | N/A          | `[path]`, `--dry-run`, `--no-cache` |
 | `yii:user-findone-to-identity` | Replaces redundant `User::findOne(...)` lookups for current user with `Yii::$app->user->identity`    | N/A          | `[path]`, `--dry-run`, `--no-cache` |
+
+### 🧩 Laravel Framework Extensions
+
+| Command | Description | Danger Level | Options |
+| ---------------------- | --------------------------------------------- | ------------ | ---------------------------- |
+| `laravel:all` | Runs all Laravel-specific Rector refactorings in sequence | 🟢 LOW | `[path]`, `--dry-run`, `--force` |
+
 
 ## 📁 Configuration
 

--- a/config.php
+++ b/config.php
@@ -201,6 +201,9 @@ return [
         ],
     ],
     CommandGroup::LARAVEL->value => [
-        //
+        \Vix\Syntra\Commands\Extension\Laravel\LaravelAllCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
     ],
 ];

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -155,7 +155,7 @@ return [
 ### Extension Commands
 
 -   **`yii`** (`CommandGroup::YII`): Yii framework-specific commands
--   **`laravel`** (`CommandGroup::LARAVEL`): Laravel framework-specific commands (planned)
+-   **`laravel`** (`CommandGroup::LARAVEL`): Laravel framework-specific commands
 
 ## Security Considerations
 

--- a/src/Commands/Extension/Laravel/LaravelAllCommand.php
+++ b/src/Commands/Extension/Laravel/LaravelAllCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Extension\Laravel;
+
+use Vix\Syntra\Commands\RectorRunnerCommand;
+
+class LaravelAllCommand extends RectorRunnerCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('laravel:all')
+            ->setDescription('Runs all Laravel-specific Rector refactorings in sequence')
+            ->setHelp('Usage: vendor/bin/syntra laravel:all');
+    }
+
+    protected function getRectorRules(): array
+    {
+        return [];
+    }
+
+    protected function getSuccessMessage(): string
+    {
+        return 'All Laravel Rector refactorings completed.';
+    }
+
+    protected function getErrorMessage(): string
+    {
+        return 'Laravel Rector refactoring crashed.';
+    }
+}

--- a/src/Commands/Refactor/RefactorAllCommand.php
+++ b/src/Commands/Refactor/RefactorAllCommand.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Commands\Refactor;
 
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Traits\CommandRunnerTrait;
+use Vix\Syntra\Utils\ProjectDetector;
+use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
+use Vix\Syntra\Commands\Extension\Laravel\LaravelAllCommand;
 
 class RefactorAllCommand extends SyntraRefactorCommand
 {
     use CommandRunnerTrait;
+
+    private bool $runFramework = false;
 
     protected function configure(): void
     {
@@ -20,8 +28,16 @@ class RefactorAllCommand extends SyntraRefactorCommand
         $this
             ->setName('refactor:all')
             ->setDescription('Runs all enabled refactor commands in sequence')
-            ->setHelp('Usage: vendor/bin/syntra refactor:all')
-            ->setDangerLevel(DangerLevel::HIGH);
+            ->setHelp('Usage: vendor/bin/syntra refactor:all [--framework]')
+            ->setDangerLevel(DangerLevel::HIGH)
+            ->addOption('framework', null, InputOption::VALUE_NONE, 'Also run framework-specific refactorings (Yii or Laravel)');
+    }
+
+    protected function initialize(InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): void
+    {
+        $this->runFramework = (bool) $input->getOption('framework');
+
+        parent::initialize($input, $output);
     }
 
     public function perform(): int
@@ -40,6 +56,43 @@ class RefactorAllCommand extends SyntraRefactorCommand
             }
         }
 
+        if ($this->runFramework) {
+            $detector = new ProjectDetector();
+            $type = $detector->detect((string) Config::getProjectRoot());
+
+            if ($type === ProjectDetector::TYPE_YII) {
+                $exitCode = $this->runCommand(YiiAllCommand::class, $this->getForwardOptions());
+                if ($exitCode !== self::SUCCESS) {
+                    $hasErrors = true;
+                }
+            } elseif ($type === ProjectDetector::TYPE_LARAVEL) {
+                $exitCode = $this->runCommand(LaravelAllCommand::class, $this->getForwardOptions());
+                if ($exitCode !== self::SUCCESS) {
+                    $hasErrors = true;
+                }
+            } else {
+                $this->output->warning('Framework not detected; skipping framework-specific refactor.');
+            }
+        }
+
         return $hasErrors ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Forward common options to sub-commands.
+     *
+     * @return array<string,mixed>
+     */
+    private function getForwardOptions(): array
+    {
+        $opts = [];
+        if ($this->dryRun) {
+            $opts['--dry-run'] = true;
+        }
+        if ($this->force) {
+            $opts['--force'] = true;
+        }
+
+        return $opts;
     }
 }

--- a/tests/Commands/RefactorAllFrameworkTest.php
+++ b/tests/Commands/RefactorAllFrameworkTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Command\Command;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\Refactor\RefactorAllCommand;
+use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Utils\FileHelper;
+
+class RefactorAllFrameworkTest extends TestCase
+{
+    public function testRunsFrameworkCommandWhenOptionEnabled(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents("$dir/composer.json", json_encode([
+            'require' => [
+                'yiisoft/yii2' => '*',
+            ],
+        ]));
+
+        FileHelper::clearCache();
+
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+
+        $command = new class extends RefactorAllCommand {
+            public array $executed = [];
+            protected function runCommand(string $class, array $input = []): int
+            {
+                $this->executed[] = $class;
+                return Command::SUCCESS;
+            }
+        };
+
+        $app->add($command);
+        $tester = new CommandTester($command);
+        $tester->execute(['--framework' => true, '--force' => true]);
+
+        $this->assertContains('Vix\\Syntra\\Commands\\Extension\\Yii\\YiiAllCommand', $command->executed);
+
+        unlink("$dir/composer.json");
+        rmdir($dir);
+    }
+}

--- a/tests/Utils/ProjectDetectorTest.php
+++ b/tests/Utils/ProjectDetectorTest.php
@@ -27,6 +27,25 @@ class ProjectDetectorTest extends TestCase
         rmdir($dir);
     }
 
+    public function testDetectsLaravelProject(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents("$dir/composer.json", json_encode([
+            'require' => [
+                'laravel/framework' => '*',
+            ],
+        ]));
+
+        FileHelper::clearCache();
+
+        $detector = new ProjectDetector();
+        $this->assertSame(ProjectDetector::TYPE_LARAVEL, $detector->detect($dir));
+
+        unlink("$dir/composer.json");
+        rmdir($dir);
+    }
+
     public function testDetectsUnknownProject(): void
     {
         $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();


### PR DESCRIPTION
## Summary
- add `--framework` option to `refactor:all` command
- auto-run `yii:all` or `laravel:all` when framework detected
- add LaravelAllCommand placeholder
- document new command and option
- support Laravel detection
- add unit tests for framework option and detector

## Testing
- `vendor/bin/phpunit`