### PR TITLE
Support readonly class modifiers for docblock refactor

### DIFF
--- a/src/Commands/Refactor/DocblockRefactorer.php
+++ b/src/Commands/Refactor/DocblockRefactorer.php
@@ -95,12 +95,13 @@ class DocblockRefactorer extends SyntraRefactorCommand
             if (!$hasDocBlock) {
                 $insertIndex = $i;
 
-                // Place docblock before class modifiers like final or abstract
+                // Place docblock before class modifiers like final, abstract, or readonly
                 $checkIndex = $prevTokenIndex;
+                $modifiers = $this->getClassModifierTokens();
                 while (
                     $checkIndex !== null &&
                     is_array($tokens[$checkIndex]) &&
-                    in_array($tokens[$checkIndex][0], [T_FINAL, T_ABSTRACT], true)
+                    in_array($tokens[$checkIndex][0], $modifiers, true)
                 ) {
                     $insertIndex = $checkIndex;
                     $checkIndex = $this->getPreviousTokenIndex($tokens, $insertIndex);
@@ -182,6 +183,16 @@ class DocblockRefactorer extends SyntraRefactorCommand
             return $i;
         }
         return null;
+    }
+
+    /**
+     * Returns an array of tokens that represent class modifiers.
+     *
+     * @return array<int>
+     */
+    private function getClassModifierTokens(): array
+    {
+        return [T_FINAL, T_ABSTRACT, T_READONLY];
     }
 
     /**

--- a/tests/Commands/DocblockRefactorerTest.php
+++ b/tests/Commands/DocblockRefactorerTest.php
@@ -74,4 +74,26 @@ class DocblockRefactorerTest extends TestCase
         $this->assertMatchesRegularExpression('/\/\*\*.*Class.*\*\/\s*abstract class/s', $result);
         $this->assertDoesNotMatchRegularExpression('/abstract\s*\n\s*\/\*/', $result);
     }
+
+    public function testDocblockInsertedBeforeReadonlyClass(): void
+    {
+        $content = "<?php\nreadonly class Baz {}\n";
+        $this->createFile($content);
+
+        $result = $this->runCommand();
+
+        $this->assertMatchesRegularExpression('/\/\*\*.*Class.*\*\/\s*readonly class/s', $result);
+        $this->assertDoesNotMatchRegularExpression('/readonly\s*\n\s*\/\*/', $result);
+    }
+
+    public function testDocblockInsertedBeforeFinalReadonlyClass(): void
+    {
+        $content = "<?php\nfinal readonly class Qux {}\n";
+        $this->createFile($content);
+
+        $result = $this->runCommand();
+
+        $this->assertMatchesRegularExpression('/\/\*\*.*Class.*\*\/\s*final readonly class/s', $result);
+        $this->assertDoesNotMatchRegularExpression('/readonly\s*\n\s*\/\*/', $result);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `refactor:docblocks` places docblocks before `readonly` modifier and any future class modifier tokens
- extend the tests for the docblock refactoring to cover `readonly` and combination of `final readonly`
- simplify detection of class modifiers using a static token list

## Testing
- `vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_686bac092e488322acdb5655e1654587