### PR TITLE
Add output file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 -   **No-Cache Option**: Use `--no-cache` to disable caching for a single command run.
 -   **Facades**: Convenient static access to common services.
 -   **Progress Indicators**: Choose between spinner, progress bar, bouncing, or none via the `ProgressIndicatorType` enum.
+-   **Output Logging**: Use `--output-file=FILE` to save command output.
 
 ## 📦 Installation
 
@@ -75,6 +76,7 @@ All commands support these standard options (with an optional `[path]` argument 
 -   `--no-cache`: Disable file caching (useful for temporary directories)
 -   `--fail-on-warning`: Return exit code 1 if warnings were found
 -   `--ci`: CI mode, implies `--no-progress` and `--fail-on-warning`
+-   `--output-file=FILE`: Write all command output to FILE
 -   `--help` / `-h`: Display help for the command
 -   `--quiet` / `-q`: Only show errors
 -   `--verbose` / `-v/-vv/-vvv`: Increase verbosity level

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -16,6 +16,8 @@ use Vix\Syntra\ProgressIndicators\ProgressIndicatorFactory;
 use Vix\Syntra\ProgressIndicators\ProgressIndicatorInterface;
 use Vix\Syntra\Traits\HasStyledOutput;
 use Vix\Syntra\Utils\FileHelper;
+use Vix\Syntra\Utils\TeeOutput;
+use Symfony\Component\Console\Output\StreamOutput;
 
 abstract class SyntraCommand extends Command
 {
@@ -28,6 +30,8 @@ abstract class SyntraCommand extends Command
     protected bool $noCache = false;
     protected bool $failOnWarning = false;
     protected bool $ciMode = false;
+
+    protected ?string $outputFile = null;
 
     protected ProgressIndicatorInterface $progressIndicator;
 
@@ -48,12 +52,23 @@ abstract class SyntraCommand extends Command
             ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Disable progress output')
             ->addOption('no-cache', null, InputOption::VALUE_NONE, 'Disable file caching')
             ->addOption('fail-on-warning', null, InputOption::VALUE_NONE, 'Return exit code 1 if warnings were found')
-            ->addOption('ci', null, InputOption::VALUE_NONE, 'CI mode (implies --no-progress and --fail-on-warning)');
+            ->addOption('ci', null, InputOption::VALUE_NONE, 'CI mode (implies --no-progress and --fail-on-warning)')
+            ->addOption('output-file', null, InputOption::VALUE_OPTIONAL, 'Write command output to the given file');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->input = $input;
+
+        $this->outputFile = $input->getOption('output-file');
+        if ($this->outputFile !== null) {
+            $stream = fopen($this->outputFile, 'w');
+            if ($stream !== false) {
+                $fileOutput = new StreamOutput($stream);
+                $output = new TeeOutput($output, $fileOutput);
+            }
+        }
+
         $this->output = new SymfonyStyle($input, $output);
 
         $this->dryRun = (bool) $input->getOption('dry-run');

--- a/src/Utils/TeeOutput.php
+++ b/src/Utils/TeeOutput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Utils;
+
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Output that writes messages to two underlying outputs simultaneously.
+ */
+class TeeOutput extends Output
+{
+    public function __construct(private OutputInterface $first, private OutputInterface $second)
+    {
+        parent::__construct($first->getVerbosity(), $first->isDecorated(), $first->getFormatter());
+    }
+
+    protected function doWrite(string $message, bool $newline): void
+    {
+        $this->first->write($message, $newline);
+        $this->second->write($message, $newline);
+    }
+
+    public function setDecorated(bool $decorated): void
+    {
+        parent::setDecorated($decorated);
+        $this->first->setDecorated($decorated);
+        $this->second->setDecorated($decorated);
+    }
+
+    public function setVerbosity(int $level): void
+    {
+        parent::setVerbosity($level);
+        $this->first->setVerbosity($level);
+        $this->second->setVerbosity($level);
+    }
+}

--- a/tests/Commands/OutputFileTest.php
+++ b/tests/Commands/OutputFileTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class OutputFileTest extends TestCase
+{
+    private function makeCommand(): SyntraCommand
+    {
+        return new class () extends SyntraCommand {
+            protected function configure(): void
+            {
+                parent::configure();
+                $this->setName('dummy:output');
+            }
+
+            public function perform(): int
+            {
+                $this->output->writeln('hello');
+                return Command::SUCCESS;
+            }
+        };
+    }
+
+    public function testWritesToOutputFile(): void
+    {
+        $app = new Application();
+        $container = $app->getContainer();
+        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+
+        $command = $this->makeCommand();
+        $app->add($command);
+        $tester = new CommandTester($command);
+
+        $file = tempnam(sys_get_temp_dir(), 'syntra_log');
+        $tester->execute(['--output-file' => $file]);
+
+        $this->assertFileExists($file);
+        $this->assertStringContainsString('hello', file_get_contents($file));
+
+        unlink($file);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `TeeOutput` helper
- support `--output-file` option in `SyntraCommand`
- document new option
- test that command output can be redirected to a file

## Testing
- `composer install`
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_686baf10af3483229c022a1e5e3aed5e