### PR TITLE
Exclude rector vendor from PHPStan scanning

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
     paths:
         - ../src
         - ../tests
+    excludePaths:
+        - ../vendor/rector/rector/vendor/*

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -8,4 +8,4 @@ parameters:
         - ../src
         - ../tests
     excludePaths:
-        - ../vendor/rector/rector/vendor/*
+        - ../vendor/*


### PR DESCRIPTION
## Summary
- avoid PHPStan analyzing rector's bundled vendor directory

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml --stop-on-failure`