### PR TITLE
Make danger warning more verbose

### DIFF
--- a/src/Traits/HasDangerLevel.php
+++ b/src/Traits/HasDangerLevel.php
@@ -42,7 +42,8 @@ trait HasDangerLevel
             $helper = $this->getHelper('question');
 
             $output->writeln(sprintf(
-                '<comment>Warning: the danger level of this command is marked as %s and it may be unsafe.</comment>',
+                '<comment>Warning: the danger level of command "%s" is marked as %s and it may be unsafe.</comment>',
+                $this->getName(),
                 $this->getDangerLevel()->value,
             ));
 

--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -38,6 +38,6 @@ class DangerLevelWarningTest extends TestCase
         $tester = new CommandTester($command);
         $tester->execute([]);
 
-        $this->assertStringContainsString('Warning: the danger level of this command is marked as', $tester->getDisplay());
+        $this->assertStringContainsString('Warning: the danger level of command "dummy:danger" is marked as', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
## Summary
- clarify danger message in `HasDangerLevel` trait to show command name
- update `DangerLevelWarningTest` to match new message

## Testing
- `vendor/bin/phpunit`