### PR TITLE
Fix progress indicator throttling

### DIFF
--- a/src/ProgressIndicators/BouncingIndicator.php
+++ b/src/ProgressIndicators/BouncingIndicator.php
@@ -14,14 +14,20 @@ class BouncingIndicator extends AbstractProgressIndicator
 
     private bool $isRunning = false;
 
-    public function __construct(protected SymfonyStyle $output, private readonly int $width = 10)
-    {
+    private float $lastUpdate = 0.0;
+
+    public function __construct(
+        protected SymfonyStyle $output,
+        private readonly int $width = 10,
+        private readonly float $updateInterval = 0.1
+    ) {
         parent::__construct($output);
     }
 
     public function start(): void
     {
         $this->isRunning = true;
+        $this->lastUpdate = microtime(true);
         $this->render();
     }
 
@@ -30,6 +36,13 @@ class BouncingIndicator extends AbstractProgressIndicator
         if (!$this->isRunning) {
             return;
         }
+
+        $now = microtime(true);
+        if ($now - $this->lastUpdate < $this->updateInterval) {
+            return;
+        }
+
+        $this->lastUpdate = $now;
 
         $this->position += $this->direction;
 

--- a/src/ProgressIndicators/SpinnerIndicator.php
+++ b/src/ProgressIndicators/SpinnerIndicator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\ProgressIndicators;
 
+use Symfony\Component\Console\Style\SymfonyStyle;
+
 class SpinnerIndicator extends AbstractProgressIndicator
 {
     private array $spinnerChars = ['⠏', '⠛', '⠹', '⢸', '⣰', '⣤', '⣆', '⡇'];
@@ -12,9 +14,19 @@ class SpinnerIndicator extends AbstractProgressIndicator
 
     private bool $isRunning = false;
 
+    private float $lastUpdate = 0.0;
+
+    public function __construct(
+        protected SymfonyStyle $output,
+        private readonly float $updateInterval = 0.1
+    ) {
+        parent::__construct($output);
+    }
+
     public function start(): void
     {
         $this->isRunning = true;
+        $this->lastUpdate = microtime(true);
         $this->render();
     }
 
@@ -23,6 +35,13 @@ class SpinnerIndicator extends AbstractProgressIndicator
         if (!$this->isRunning) {
             return;
         }
+
+        $now = microtime(true);
+        if ($now - $this->lastUpdate < $this->updateInterval) {
+            return;
+        }
+
+        $this->lastUpdate = $now;
 
         $this->spinnerIndex = ($this->spinnerIndex + 1) % count($this->spinnerChars);
         $this->render();


### PR DESCRIPTION
## Summary
- adjust bouncing indicator to update at most every 0.1s
- adjust spinner indicator to update at most every 0.1s

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686be3e806208322a14c61a8f5ae9c1a