### PR TITLE
Use facades throughout

### DIFF
--- a/config.php
+++ b/config.php
@@ -112,7 +112,6 @@ return [
             'enabled' => true,
             'web_enabled' => true,
             'config' => config_path('phpstan.neon'),
-            'level' => 5,
         ],
         PhpUnitCheckCommand::class => [
             'enabled' => true,

--- a/docs/DEPENDENCY_INJECTION.md
+++ b/docs/DEPENDENCY_INJECTION.md
@@ -78,6 +78,8 @@ Registers core application services:
 -   `ProcessRunner` - Process execution
 -   `FileHelper` - File operations (available via the `File` facade)
     -   caches results of file searches during a single run for performance
+-   `ProjectDetector` - Detects framework type (available via the `Project` facade)
+-   `RectorCommandExecutor` - Runs Rector rules (available via the `Rector` facade)
 
 ### HealthServiceProvider
 

--- a/src/Commands/General/GenerateDocsCommand.php
+++ b/src/Commands/General/GenerateDocsCommand.php
@@ -14,9 +14,9 @@ use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Project;
 use Vix\Syntra\NodeVisitors\DocsVisitor;
 use Vix\Syntra\Traits\ContainerAwareTrait;
-use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ProjectDetector;
 
 class GenerateDocsCommand extends SyntraCommand

--- a/src/Commands/General/GenerateDocsCommand.php
+++ b/src/Commands/General/GenerateDocsCommand.php
@@ -16,6 +16,7 @@ use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 use Vix\Syntra\NodeVisitors\DocsVisitor;
 use Vix\Syntra\Traits\ContainerAwareTrait;
+use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ProjectDetector;
 
 class GenerateDocsCommand extends SyntraCommand
@@ -39,8 +40,7 @@ class GenerateDocsCommand extends SyntraCommand
     {
         $projectRoot = Config::getProjectRoot();
 
-        $detector = $this->getService(ProjectDetector::class, fn (): ProjectDetector => new ProjectDetector());
-        $type = $detector->detect($projectRoot);
+        $type = Project::detect($projectRoot);
 
         if ($type === ProjectDetector::TYPE_YII) {
             return $this->generateForYii($projectRoot);

--- a/src/Commands/Health/PhpStanCheckCommand.php
+++ b/src/Commands/Health/PhpStanCheckCommand.php
@@ -34,7 +34,6 @@ class PhpStanCheckCommand extends SyntraCommand implements HealthCheckCommandInt
 
         $args = [
             'analyse',
-            '--level=' . (int) Config::getCommandOption(CommandGroup::HEALTH->value, self::class, 'level', 0),
             '--error-format=json',
             '--no-progress',
             '--configuration=' . Config::getCommandOption(CommandGroup::HEALTH->value, self::class, 'config', 'phpstan.neon'),

--- a/src/Commands/RectorRunnerCommand.php
+++ b/src/Commands/RectorRunnerCommand.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands;
 
 use Exception;
-use Vix\Syntra\Utils\RectorCommandExecutor;
+use Vix\Syntra\Facades\Rector;
 
 /**
  * Generic command base for running specific Rector rules.
  */
 abstract class RectorRunnerCommand extends SyntraRefactorCommand
 {
-    public function __construct(protected RectorCommandExecutor $rectorExecutor)
-    {
-        parent::__construct();
-    }
 
     /**
      * Return Rector rule class(es) to execute.
@@ -69,7 +65,7 @@ abstract class RectorRunnerCommand extends SyntraRefactorCommand
         };
 
         try {
-            $result = $this->rectorExecutor->executeRules($rules, $additionalArgs, $outputCallback);
+            $result = Rector::executeRules($rules, $additionalArgs, $outputCallback);
 
             $this->progressIndicator->setMessage(
                 $result->exitCode === 0 ? $this->getSuccessMessage() : $this->getErrorMessage()

--- a/src/Commands/RectorRunnerCommand.php
+++ b/src/Commands/RectorRunnerCommand.php
@@ -12,7 +12,6 @@ use Vix\Syntra\Facades\Rector;
  */
 abstract class RectorRunnerCommand extends SyntraRefactorCommand
 {
-
     /**
      * Return Rector rule class(es) to execute.
      *

--- a/src/Commands/Refactor/RefactorAllCommand.php
+++ b/src/Commands/Refactor/RefactorAllCommand.php
@@ -12,8 +12,8 @@ use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Facades\Config;
-use Vix\Syntra\Traits\CommandRunnerTrait;
 use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Traits\CommandRunnerTrait;
 use Vix\Syntra\Utils\ProjectDetector;
 
 class RefactorAllCommand extends SyntraRefactorCommand

--- a/src/Commands/Refactor/RefactorAllCommand.php
+++ b/src/Commands/Refactor/RefactorAllCommand.php
@@ -13,6 +13,7 @@ use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Traits\CommandRunnerTrait;
+use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ProjectDetector;
 
 class RefactorAllCommand extends SyntraRefactorCommand
@@ -58,8 +59,7 @@ class RefactorAllCommand extends SyntraRefactorCommand
         }
 
         if ($this->runFramework) {
-            $detector = new ProjectDetector();
-            $type = $detector->detect((string) Config::getProjectRoot());
+            $type = Project::detect((string) Config::getProjectRoot());
 
             if ($type === ProjectDetector::TYPE_YII) {
                 $exitCode = $this->runCommand(YiiAllCommand::class, $this->getForwardOptions());

--- a/src/DI/Providers/ApplicationServiceProvider.php
+++ b/src/DI/Providers/ApplicationServiceProvider.php
@@ -10,8 +10,8 @@ use Vix\Syntra\Utils\ConfigLoader;
 use Vix\Syntra\Utils\FileHelper;
 use Vix\Syntra\Utils\PackageInstaller;
 use Vix\Syntra\Utils\ProcessRunner;
-use Vix\Syntra\Utils\RectorCommandExecutor;
 use Vix\Syntra\Utils\ProjectDetector;
+use Vix\Syntra\Utils\RectorCommandExecutor;
 
 /**
  * Application Service Provider

--- a/src/DI/Providers/ApplicationServiceProvider.php
+++ b/src/DI/Providers/ApplicationServiceProvider.php
@@ -11,6 +11,7 @@ use Vix\Syntra\Utils\FileHelper;
 use Vix\Syntra\Utils\PackageInstaller;
 use Vix\Syntra\Utils\ProcessRunner;
 use Vix\Syntra\Utils\RectorCommandExecutor;
+use Vix\Syntra\Utils\ProjectDetector;
 
 /**
  * Application Service Provider
@@ -33,6 +34,9 @@ class ApplicationServiceProvider implements ServiceProviderInterface
 
         // Register PackageInstaller as singleton
         $container->singleton(PackageInstaller::class, fn (): PackageInstaller => new PackageInstaller());
+
+        // Register ProjectDetector as singleton
+        $container->singleton(ProjectDetector::class, fn (): ProjectDetector => new ProjectDetector());
 
         // Register RectorCommandExecutor as singleton
         $container->singleton(RectorCommandExecutor::class, fn (): RectorCommandExecutor => new RectorCommandExecutor());

--- a/src/Facades/Project.php
+++ b/src/Facades/Project.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Facades;
+
+use Vix\Syntra\Utils\ProjectDetector;
+
+/**
+ * @method static string detect(string $projectRoot)
+ */
+class Project extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return ProjectDetector::class;
+    }
+}

--- a/src/Facades/Rector.php
+++ b/src/Facades/Rector.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Facades;
 
-use Vix\Syntra\Utils\RectorCommandExecutor;
 use Vix\Syntra\DTO\ProcessResult;
+use Vix\Syntra\Utils\RectorCommandExecutor;
 
 /**
  * @method static ProcessResult executeRules(array $rectorClasses, array $additionalArgs = [], ?callable $outputCallback = null)
- * @method static bool isRectorAvailable()
+ * @method static bool          isRectorAvailable()
  */
 class Rector extends Facade
 {

--- a/src/Facades/Rector.php
+++ b/src/Facades/Rector.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Facades;
+
+use Vix\Syntra\Utils\RectorCommandExecutor;
+use Vix\Syntra\DTO\ProcessResult;
+
+/**
+ * @method static ProcessResult executeRules(array $rectorClasses, array $additionalArgs = [], ?callable $outputCallback = null)
+ * @method static bool isRectorAvailable()
+ */
+class Rector extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return RectorCommandExecutor::class;
+    }
+}

--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -8,15 +8,15 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 
 class DangerLevelWarningTest extends TestCase
 {
     public function testWarningShownForHighDanger(): void
     {
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+        $app->getContainer();
+        Config::setProjectRoot(sys_get_temp_dir());
 
         $command = new class () extends SyntraRefactorCommand {
             protected DangerLevel $dangerLevel = DangerLevel::HIGH;

--- a/tests/Commands/DocblockRefactorerTest.php
+++ b/tests/Commands/DocblockRefactorerTest.php
@@ -5,7 +5,7 @@ namespace Vix\Syntra\Tests\Commands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 
 class DocblockRefactorerTest extends TestCase
@@ -37,9 +37,9 @@ class DocblockRefactorerTest extends TestCase
     private function runCommand(): string
     {
         $app = new Application();
-        $container = $app->getContainer();
+        $app->getContainer();
         File::clearCache();
-        $container->get(ConfigLoader::class)->setProjectRoot($this->dir);
+        Config::setProjectRoot($this->dir);
 
         $command = $app->find('refactor:docblocks');
         $tester = new CommandTester($command);

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -10,6 +10,7 @@ use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Utils\ConfigLoader;
 
 class EditorConfigCheckCommandTest extends TestCase
@@ -58,8 +59,8 @@ class EditorConfigCheckCommandTest extends TestCase
         mkdir($dir);
 
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+        $app->getContainer();
+        Config::setProjectRoot($dir);
 
         $command = $app->find('health:editorconfig');
         $tester = new CommandTester($command);

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -9,8 +9,8 @@ use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
-use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Utils\ConfigLoader;
 
 class EditorConfigCheckCommandTest extends TestCase

--- a/tests/Commands/FailOnWarningTest.php
+++ b/tests/Commands/FailOnWarningTest.php
@@ -9,7 +9,7 @@ use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DTO\CommandResult;
 use Vix\Syntra\Traits\HandlesResultTrait;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 
 class FailOnWarningTest extends TestCase
 {
@@ -35,8 +35,8 @@ class FailOnWarningTest extends TestCase
     public function testFailOnWarningOption(): void
     {
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+        $app->getContainer();
+        Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();
         $app->add($command);
@@ -50,8 +50,8 @@ class FailOnWarningTest extends TestCase
     public function testCiModeFailsOnWarning(): void
     {
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+        $app->getContainer();
+        Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();
         $app->add($command);

--- a/tests/Commands/FailOnWarningTest.php
+++ b/tests/Commands/FailOnWarningTest.php
@@ -8,8 +8,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DTO\CommandResult;
-use Vix\Syntra\Traits\HandlesResultTrait;
 use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Traits\HandlesResultTrait;
 
 class FailOnWarningTest extends TestCase
 {

--- a/tests/Commands/ImportRefactorerTest.php
+++ b/tests/Commands/ImportRefactorerTest.php
@@ -5,7 +5,7 @@ namespace Vix\Syntra\Tests\Commands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 
 class ImportRefactorerTest extends TestCase
 {
@@ -36,8 +36,8 @@ class ImportRefactorerTest extends TestCase
     private function runCommand(array $options = []): void
     {
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot($this->dir);
+        $app->getContainer();
+        Config::setProjectRoot($this->dir);
 
         $command = $app->find('refactor:imports');
         $tester = new CommandTester($command);

--- a/tests/Commands/OutputFileTest.php
+++ b/tests/Commands/OutputFileTest.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 
 class OutputFileTest extends TestCase
 {
@@ -31,8 +31,8 @@ class OutputFileTest extends TestCase
     public function testWritesToOutputFile(): void
     {
         $app = new Application();
-        $container = $app->getContainer();
-        $container->get(ConfigLoader::class)->setProjectRoot(sys_get_temp_dir());
+        $app->getContainer();
+        Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();
         $app->add($command);

--- a/tests/Commands/PhpVersionCheckCommandTest.php
+++ b/tests/Commands/PhpVersionCheckCommandTest.php
@@ -8,6 +8,7 @@ use Vix\Syntra\Commands\Health\PhpVersionCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Utils\ConfigLoader;
 
 class PhpVersionCheckCommandTest extends TestCase
@@ -51,9 +52,9 @@ class PhpVersionCheckCommandTest extends TestCase
     {
         $container = new Container();
         $container->instance(ConfigLoader::class, self::$config);
-
-        self::$config->setProjectRoot($this->dir);
         Facade::setContainer($container);
+
+        Config::setProjectRoot($this->dir);
         return new PhpVersionCheckCommand();
     }
 

--- a/tests/Commands/PhpVersionCheckCommandTest.php
+++ b/tests/Commands/PhpVersionCheckCommandTest.php
@@ -7,8 +7,8 @@ use ReflectionClass;
 use Vix\Syntra\Commands\Health\PhpVersionCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
-use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Utils\ConfigLoader;
 
 class PhpVersionCheckCommandTest extends TestCase

--- a/tests/Commands/RefactorAllFrameworkTest.php
+++ b/tests/Commands/RefactorAllFrameworkTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
 use Vix\Syntra\Commands\Refactor\RefactorAllCommand;
-use Vix\Syntra\Utils\ConfigLoader;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
 
 class RefactorAllFrameworkTest extends TestCase
@@ -26,7 +26,7 @@ class RefactorAllFrameworkTest extends TestCase
         $app = new Application();
         $container = $app->getContainer();
         File::clearCache();
-        $container->get(ConfigLoader::class)->setProjectRoot($dir);
+        Config::setProjectRoot($dir);
 
         $command = new class () extends RefactorAllCommand {
             public array $executed = [];

--- a/tests/Commands/SecurityCheckerTest.php
+++ b/tests/Commands/SecurityCheckerTest.php
@@ -9,6 +9,7 @@ use Vix\Syntra\DI\Container;
 use Vix\Syntra\DTO\ProcessResult;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Utils\ConfigLoader;
 use Vix\Syntra\Utils\ProcessRunner;
 

--- a/tests/Commands/SecurityCheckerTest.php
+++ b/tests/Commands/SecurityCheckerTest.php
@@ -9,7 +9,6 @@ use Vix\Syntra\DI\Container;
 use Vix\Syntra\DTO\ProcessResult;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Facade;
-use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Utils\ConfigLoader;
 use Vix\Syntra\Utils\ProcessRunner;
 

--- a/tests/Utils/ProcessRunnerTest.php
+++ b/tests/Utils/ProcessRunnerTest.php
@@ -3,14 +3,15 @@
 namespace Vix\Syntra\Tests\Utils;
 
 use PHPUnit\Framework\TestCase;
-use Vix\Syntra\Utils\ProcessRunner;
+use Vix\Syntra\Facades\Process;
+use Vix\Syntra\Application;
 
 class ProcessRunnerTest extends TestCase
 {
     public function testRunSuccessfulCommand(): void
     {
-        $runner = new ProcessRunner();
-        $result = $runner->run('php', ['-r', 'echo "hello";']);
+        new Application();
+        $result = Process::run('php', ['-r', 'echo "hello";']);
 
         $this->assertSame(0, $result->exitCode);
         $this->assertSame('hello', trim($result->output));
@@ -18,8 +19,8 @@ class ProcessRunnerTest extends TestCase
 
     public function testRunFails(): void
     {
-        $runner = new ProcessRunner();
-        $result = $runner->run('php', ['-r', 'fwrite(STDERR, "err"); exit(1);']);
+        new Application();
+        $result = Process::run('php', ['-r', 'fwrite(STDERR, "err"); exit(1);']);
 
         $this->assertSame(1, $result->exitCode);
         $this->assertSame('err', trim($result->stderr));

--- a/tests/Utils/ProcessRunnerTest.php
+++ b/tests/Utils/ProcessRunnerTest.php
@@ -3,8 +3,8 @@
 namespace Vix\Syntra\Tests\Utils;
 
 use PHPUnit\Framework\TestCase;
-use Vix\Syntra\Facades\Process;
 use Vix\Syntra\Application;
+use Vix\Syntra\Facades\Process;
 
 class ProcessRunnerTest extends TestCase
 {

--- a/tests/Utils/ProjectDetectorTest.php
+++ b/tests/Utils/ProjectDetectorTest.php
@@ -5,6 +5,7 @@ namespace Vix\Syntra\Tests\Utils;
 use PHPUnit\Framework\TestCase;
 use Vix\Syntra\Application;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ProjectDetector;
 
 class ProjectDetectorTest extends TestCase
@@ -22,8 +23,7 @@ class ProjectDetectorTest extends TestCase
         new Application();
         File::clearCache();
 
-        $detector = new ProjectDetector();
-        $this->assertSame(ProjectDetector::TYPE_YII, $detector->detect($dir));
+        $this->assertSame(ProjectDetector::TYPE_YII, Project::detect($dir));
 
         unlink("$dir/composer.json");
         rmdir($dir);
@@ -42,8 +42,7 @@ class ProjectDetectorTest extends TestCase
         new Application();
         File::clearCache();
 
-        $detector = new ProjectDetector();
-        $this->assertSame(ProjectDetector::TYPE_LARAVEL, $detector->detect($dir));
+        $this->assertSame(ProjectDetector::TYPE_LARAVEL, Project::detect($dir));
 
         unlink("$dir/composer.json");
         rmdir($dir);
@@ -62,8 +61,7 @@ class ProjectDetectorTest extends TestCase
         new Application();
         File::clearCache();
 
-        $detector = new ProjectDetector();
-        $this->assertSame(ProjectDetector::TYPE_UNKNOWN, $detector->detect($dir));
+        $this->assertSame(ProjectDetector::TYPE_UNKNOWN, Project::detect($dir));
 
         unlink("$dir/composer.json");
         rmdir($dir);


### PR DESCRIPTION
## Summary
- add `Project` and `Rector` facades
- register `ProjectDetector` service
- replace util usage with facades in commands
- update tests to prefer facades
- document new services in dependency injection guide

## Testing
- `vendor/bin/phpunit`