### PR TITLE
Add limit(1) support for yii find shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ All commands support these standard options (with an optional `[path]` argument 
 | Command                        | Description                                                                                          | Danger Level | Options                             |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------ | ----------------------------------- |
 | `yii:all`                      | Runs all Yii-specific Rector refactorings in sequence                                                | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |
-| `yii:find-shortcuts`           | Converts `Model::find()->where([...])->one()/all()` into `Model::findOne([...])` or `findAll([...])` | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |
+| `yii:find-shortcuts`           | Converts `Model::find()->where([...])->one()/all()` or `Model::find()->where([...])->limit(1)->one()/all()` into `Model::findOne([...])` or `findAll([...])` | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |
 | `yii:find-one-id`              | Replaces `Model::findOne(['id' => $id])` with `Model::findOne($id)`                                  | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |
 | `yii:find-all-id`              | Replaces `Model::findAll(['id' => $id]) with Model::findAll($id)`                                    | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |
 | `yii:update-shortcut`          | Replaces `Model::find()->where([...])->update([...])` with `Model::updateAll([...], [...])`          | 🟢 LOW       | `[path]`, `--dry-run`, `--force`    |

--- a/src/Commands/Rector/FindOneFindAllShortcutRector.php
+++ b/src/Commands/Rector/FindOneFindAllShortcutRector.php
@@ -14,11 +14,12 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 /**
  * This Rector rule converts query chains like:
  * Model::find()->where([...])->one() / all()
+ * Model::find()->where([...])->limit(1)->one() / all()
  * into their shorter equivalents:
  * Model::findOne([...]) / findAll([...])
  *
  * Applies only when the call chain exactly matches the structure:
- * StaticCall::find() -> MethodCall::where(...) -> MethodCall::one()/all()
+ * StaticCall::find() -> MethodCall::where(...) -> [MethodCall::limit(1) ->] MethodCall::one()/all()
  */
 class FindOneFindAllShortcutRector extends AbstractRector
 {
@@ -30,7 +31,7 @@ class FindOneFindAllShortcutRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Converts Model::find()->where([...])->one()/all() into Model::findOne([...]) or findAll([...])',
+            'Converts Model::find()->where([...])->one()/all() or Model::find()->where([...])->limit(1)->one()/all() into Model::findOne([...]) or findAll([...])',
             []
         );
     }
@@ -64,8 +65,22 @@ class FindOneFindAllShortcutRector extends AbstractRector
             return null;
         }
 
-        // Ensure the previous call is ->where(...)
+        // Allow optional ->limit(1) before ->one()/all()
         $whereCall = $node->var;
+        if ($whereCall instanceof MethodCall && $whereCall->name instanceof Identifier && $whereCall->name->toString() === 'limit') {
+            if (count($whereCall->args) !== 1) {
+                return null;
+            }
+
+            $limitArg = $whereCall->args[0]->value;
+            if (!$limitArg instanceof \PhpParser\Node\Scalar\LNumber || $limitArg->value !== 1) {
+                return null;
+            }
+
+            $whereCall = $whereCall->var;
+        }
+
+        // Ensure the previous call is ->where(...)
         if (
             !($whereCall instanceof MethodCall) ||
             !($whereCall->name instanceof Identifier) ||


### PR DESCRIPTION
## Summary
- expand documentation for `yii:find-shortcuts`
- allow `->limit(1)` in `FindOneFindAllShortcutRector`

## Testing
- `composer exec -- phpunit`


------
https://chatgpt.com/codex/tasks/task_e_686c0bf47d788322b61f9d79b47b071e