### PR TITLE
Fix phpstan warnings in tests

### DIFF
--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -15,7 +15,6 @@ class DangerLevelWarningTest extends TestCase
     public function testWarningShownForHighDanger(): void
     {
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot(sys_get_temp_dir());
 
         $command = new class () extends SyntraRefactorCommand {

--- a/tests/Commands/DocblockRefactorerTest.php
+++ b/tests/Commands/DocblockRefactorerTest.php
@@ -37,7 +37,6 @@ class DocblockRefactorerTest extends TestCase
     private function runCommand(): string
     {
         $app = new Application();
-        $app->getContainer();
         File::clearCache();
         Config::setProjectRoot($this->dir);
 

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -59,7 +59,6 @@ class EditorConfigCheckCommandTest extends TestCase
         mkdir($dir);
 
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot($dir);
 
         $command = $app->find('health:editorconfig');

--- a/tests/Commands/FailOnWarningTest.php
+++ b/tests/Commands/FailOnWarningTest.php
@@ -35,7 +35,6 @@ class FailOnWarningTest extends TestCase
     public function testFailOnWarningOption(): void
     {
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();
@@ -50,7 +49,6 @@ class FailOnWarningTest extends TestCase
     public function testCiModeFailsOnWarning(): void
     {
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();

--- a/tests/Commands/ImportRefactorerTest.php
+++ b/tests/Commands/ImportRefactorerTest.php
@@ -36,7 +36,6 @@ class ImportRefactorerTest extends TestCase
     private function runCommand(array $options = []): void
     {
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot($this->dir);
 
         $command = $app->find('refactor:imports');

--- a/tests/Commands/OutputFileTest.php
+++ b/tests/Commands/OutputFileTest.php
@@ -31,7 +31,6 @@ class OutputFileTest extends TestCase
     public function testWritesToOutputFile(): void
     {
         $app = new Application();
-        $app->getContainer();
         Config::setProjectRoot(sys_get_temp_dir());
 
         $command = $this->makeCommand();


### PR DESCRIPTION
## Summary
- remove unused getContainer() calls in tests

## Testing
- `composer exec -- phpstan analyse -c config/phpstan.neon`
- `vendor/bin/phpunit -c phpunit.xml --colors=never`