### PR TITLE
Add strict types coverage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ All commands support these standard options (with an optional `[path]` argument 
 | `analyze:find-debug-calls`   | Checks that var_dump, dd, print_r, eval, and other calls prohibited in production | `[path]`, `--dry-run`, `--no-cache`          |
 | `analyze:find-long-methods`  | Finds all methods or functions that exceed a specified number of lines            | `[path]`, `--dry-run`, `--max`, `--no-cache` |
 | `analyze:find-bad-practices` | Detects bad practices in code like magic numbers, nested ternaries                | `[path]`, `--dry-run`, `--no-cache`          |
+| `analyze:strict-types`      | Calculates percentage of files declaring `strict_types=1`                          | `[path]`, `--dry-run`, `--no-cache` |
 | `analyze:all`                | Runs all enabled analyze commands sequentially                                    | `[path]`, `--dry-run`, `--no-cache`          |
 
 ### 🏥 Health
@@ -108,7 +109,7 @@ All commands support these standard options (with an optional `[path]` argument 
 
 -   Ensure an `.editorconfig` file is present for consistent formatting
 -   Run PHP-CS-Fixer in dry-run mode to enforce PSR-12 style
--   Check for `declare(strict_types=1)` at the top of PHP files
+-   Check strict types declarations using `analyze:strict-types`
 -   Verify Composer package licenses match your project policy
 
 ### 🔧 Refactor

--- a/config.php
+++ b/config.php
@@ -7,6 +7,7 @@ use Vix\Syntra\Commands\Analyze\FindBadPracticesCommand;
 use Vix\Syntra\Commands\Analyze\FindDebugCallsCommand;
 use Vix\Syntra\Commands\Analyze\FindLongMethodsCommand;
 use Vix\Syntra\Commands\Analyze\FindTodosCommand;
+use Vix\Syntra\Commands\Analyze\StrictTypesCoverageCommand;
 use Vix\Syntra\Commands\Extension\Laravel\LaravelAllCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
 use Vix\Syntra\Commands\Extension\Yii\YiiCanHelpersCommand;
@@ -144,6 +145,10 @@ return [
             'web_enabled' => true,
         ],
         FindBadPracticesCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
+        StrictTypesCoverageCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
         ],

--- a/src/Commands/Analyze/StrictTypesCoverageCommand.php
+++ b/src/Commands/Analyze/StrictTypesCoverageCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Analyze;
+
+use Symfony\Component\Console\Command\Command;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\Enums\ProgressIndicatorType;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+
+class StrictTypesCoverageCommand extends SyntraCommand
+{
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('analyze:strict-types')
+            ->setDescription('Shows coverage of PHP files using declare(strict_types=1).')
+            ->setHelp('Usage: vendor/bin/syntra analyze:strict-types');
+    }
+
+    public function perform(): int
+    {
+        $projectRoot = Config::getProjectRoot();
+        $files = File::collectFiles($projectRoot);
+
+        $total = count($files);
+        $withStrict = 0;
+
+        $this->setProgressMax($total);
+        $this->startProgress();
+
+        foreach ($files as $file) {
+            $content = file_get_contents($file);
+            if ($content !== false && preg_match('/^\s*<\?php\s+declare\(strict_types=1\);/m', $content)) {
+                $withStrict++;
+            }
+            $this->advanceProgress();
+        }
+
+        $this->finishProgress();
+
+        $coverage = $total > 0 ? round($withStrict / $total * 100, 2) : 100.0;
+        $this->output->writeln(sprintf('Strict types coverage: %d/%d (%.1f%%)', $withStrict, $total, $coverage));
+
+        if ($withStrict === $total) {
+            $this->output->success('All files declare strict_types=1.');
+            return Command::SUCCESS;
+        }
+
+        $missing = $total - $withStrict;
+        $this->output->warning($missing . ' file(s) missing strict_types declaration.');
+        return Command::FAILURE;
+    }
+}

--- a/tests/Commands/StrictTypesCoverageCommandTest.php
+++ b/tests/Commands/StrictTypesCoverageCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+
+class StrictTypesCoverageCommandTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($this->dir);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob("$this->dir/*.php"));
+        rmdir($this->dir);
+    }
+
+    private function runCommand(): CommandTester
+    {
+        $app = new Application();
+        File::clearCache();
+        Config::setProjectRoot($this->dir);
+
+        $command = $app->find('analyze:strict-types');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
+
+        return $tester;
+    }
+
+    public function testSuccessWhenAllFilesDeclareStrict(): void
+    {
+        file_put_contents("$this->dir/a.php", "<?php\ndeclare(strict_types=1);\n");
+        file_put_contents("$this->dir/b.php", "<?php\ndeclare(strict_types=1);\n");
+
+        $tester = $this->runCommand();
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertStringContainsString('100.0%', $tester->getDisplay());
+    }
+
+    public function testFailureWhenMissingDeclarations(): void
+    {
+        file_put_contents("$this->dir/a.php", "<?php\ndeclare(strict_types=1);\n");
+        file_put_contents("$this->dir/b.php", "<?php echo 'no';\n");
+
+        $tester = $this->runCommand();
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('50.0%', $tester->getDisplay());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `analyze:strict-types` command to report coverage of `declare(strict_types=1)`
- register the command in configuration
- document the new command in README
- add tests for the command

## Testing
- `vendor/bin/phpunit --colors=never`