### PR TITLE
Add typos detection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 -   **Health Checks**: Verify project stability with Composer, PHPStan, PHPUnit, and security audits.
 -   **Code Refactoring**: Automatically fix code with custom refactorers, Rector, and PHP-CS-Fixer.
 -   **Static Analysis**: Detect todos, long methods, and unsafe debug calls.
+-   **Typo Detection**: Spot misspellings in files and identifiers using Aspell (via Peck).
 -   **Framework Support**: Built-in tooling for Yii (Laravel, Symfony planned).
 -   **Extensibility**: Generate and register new commands using stubs.
 -   **In-Memory Caching**: Reuses previously scanned file lists for faster repeated command execution.
@@ -59,6 +60,9 @@ vendor/bin/syntra health:all
 # Find TODO comments in specific directory
 vendor/bin/syntra analyze:find-todos /path/to/project
 
+# Detect typos in your project
+vendor/bin/syntra analyze:find-typos /path/to/project
+
 # Fix code style with dry-run (preview changes)
 vendor/bin/syntra refactor:cs-fixer --dry-run
 
@@ -93,6 +97,7 @@ All commands support these standard options (with an optional `[path]` argument 
 | `analyze:find-debug-calls`   | Checks that var_dump, dd, print_r, eval, and other calls prohibited in production | `[path]`, `--dry-run`, `--no-cache`          |
 | `analyze:find-long-methods`  | Finds all methods or functions that exceed a specified number of lines            | `[path]`, `--dry-run`, `--max`, `--no-cache` |
 | `analyze:find-bad-practices` | Detects bad practices in code like magic numbers, nested ternaries                | `[path]`, `--dry-run`, `--no-cache`          |
+| `analyze:find-typos`         | Detects misspellings in filenames and PHP identifiers                             | `[path]`, `--dry-run`, `--no-cache`          |
 | `analyze:strict-types`      | Calculates percentage of files declaring `strict_types=1`                          | `[path]`, `--dry-run`, `--no-cache` |
 | `analyze:all`                | Runs all enabled analyze commands sequentially                                    | `[path]`, `--dry-run`, `--no-cache`          |
 
@@ -207,6 +212,7 @@ The PHPStan health check reads from `config/phpstan.neon` by default, so tweak t
     vendor/bin/syntra analyze:find-todos
     vendor/bin/syntra analyze:find-debug-calls
     vendor/bin/syntra analyze:find-long-methods
+    vendor/bin/syntra analyze:find-typos
     ```
 
 3. **Safe Refactoring Order** (with `--dry-run` first):
@@ -239,6 +245,7 @@ Add to your CI pipeline:
   run: |
       vendor/bin/syntra health:all
       vendor/bin/syntra analyze:find-debug-calls
+      vendor/bin/syntra analyze:find-typos
 
 # Fail the pipeline on warnings
       vendor/bin/syntra health:composer --ci

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 -   **Health Checks**: Verify project stability with Composer, PHPStan, PHPUnit, and security audits.
 -   **Code Refactoring**: Automatically fix code with custom refactorers, Rector, and PHP-CS-Fixer.
 -   **Static Analysis**: Detect todos, long methods, and unsafe debug calls.
--   **Typo Detection**: Spot misspellings in files and identifiers using Aspell (via Peck).
+-   **Typo Detection**: Spot misspellings in files and identifiers using Aspell (via Peck). Requires the `aspell` binary.
 -   **Framework Support**: Built-in tooling for Yii (Laravel, Symfony planned).
 -   **Extensibility**: Generate and register new commands using stubs.
 -   **In-Memory Caching**: Reuses previously scanned file lists for faster repeated command execution.
@@ -62,6 +62,7 @@ vendor/bin/syntra analyze:find-todos /path/to/project
 
 # Detect typos in your project
 vendor/bin/syntra analyze:find-typos /path/to/project
+# Requires `aspell` to be installed and accessible in your PATH
 
 # Fix code style with dry-run (preview changes)
 vendor/bin/syntra refactor:cs-fixer --dry-run
@@ -213,6 +214,7 @@ The PHPStan health check reads from `config/phpstan.neon` by default, so tweak t
     vendor/bin/syntra analyze:find-debug-calls
     vendor/bin/syntra analyze:find-long-methods
     vendor/bin/syntra analyze:find-typos
+    # Aspell must be installed
     ```
 
 3. **Safe Refactoring Order** (with `--dry-run` first):
@@ -246,6 +248,7 @@ Add to your CI pipeline:
       vendor/bin/syntra health:all
       vendor/bin/syntra analyze:find-debug-calls
       vendor/bin/syntra analyze:find-typos
+      # install aspell via your package manager before running
 
 # Fail the pipeline on warnings
       vendor/bin/syntra health:composer --ci

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     "prefer-stable": true,
     "require-dev": {
         "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1",
+        "peckphp/peck": "^0.1.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b29e391f9a2346c1fdab6ca2e0533eea",
+    "content-hash": "647b0fa241fe1f6e598344dc0951a246",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -953,6 +953,167 @@
                 }
             ],
             "time": "2025-07-05T12:25:42+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/dfa08f390e509967a15c22493dc0bac5733d9123",
+                "reference": "dfa08f390e509967a15c22493dc0bac5733d9123",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.2",
+                "symfony/console": "^7.2.6"
+            },
+            "require-dev": {
+                "illuminate/console": "^11.44.7",
+                "laravel/pint": "^1.22.0",
+                "mockery/mockery": "^1.6.12",
+                "pestphp/pest": "^2.36.0 || ^3.8.2",
+                "phpstan/phpstan": "^1.12.25",
+                "phpstan/phpstan-strict-rules": "^1.6.2",
+                "symfony/var-dumper": "^7.2.6",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-08T08:14:37+00:00"
+        },
+        {
+            "name": "peckphp/peck",
+            "version": "v0.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/peckphp/peck.git",
+                "reference": "907d7221b057519627811c7c752d65ffa9163dc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/peckphp/peck/zipball/907d7221b057519627811c7c752d65ffa9163dc1",
+                "reference": "907d7221b057519627811c7c752d65ffa9163dc1",
+                "shasum": ""
+            },
+            "require": {
+                "nunomaduro/termwind": "^1.17.0|^2.3.0",
+                "php": "^8.2",
+                "symfony/console": "^6.4.17|^7.2.1",
+                "symfony/finder": "^6.4.17|^7.2.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.20.0",
+                "pestphp/pest": "^2.36|^3.7.4",
+                "pestphp/pest-plugin-type-coverage": "^2.8.7|^3.2.3",
+                "phpstan/phpstan": "^1.12.16",
+                "rector/rector": "^1.2.10",
+                "symfony/var-dumper": "^7.2.0"
+            },
+            "bin": [
+                "bin/peck"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Peck\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Peck is a powerful CLI tool designed to identify pure wording or spelling (grammar) mistakes in your codebase.",
+            "keywords": [
+                "checker",
+                "codebase",
+                "php",
+                "spelling"
+            ],
+            "support": {
+                "issues": "https://github.com/peckphp/peck/issues",
+                "source": "https://github.com/peckphp/peck/tree/v0.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-03-31T15:16:31+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2475,6 +2636,70 @@
                 }
             ],
             "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-12-30T19:00:26+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config.php
+++ b/config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Vix\Syntra\Commands\Analyze\AnalyzeAllCommand;
 use Vix\Syntra\Commands\Analyze\FindBadPracticesCommand;
+use Vix\Syntra\Commands\Analyze\FindTyposCommand;
 use Vix\Syntra\Commands\Analyze\FindDebugCallsCommand;
 use Vix\Syntra\Commands\Analyze\FindLongMethodsCommand;
 use Vix\Syntra\Commands\Analyze\FindTodosCommand;
@@ -145,6 +146,10 @@ return [
             'web_enabled' => true,
         ],
         FindBadPracticesCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
+        FindTyposCommand::class => [
             'enabled' => true,
             'web_enabled' => true,
         ],

--- a/src/Commands/Analyze/FindTyposCommand.php
+++ b/src/Commands/Analyze/FindTyposCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\Analyze;
+
+use Peck\Kernel;
+use Symfony\Component\Console\Command\Command;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\Enums\ProgressIndicatorType;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+
+class FindTyposCommand extends SyntraCommand
+{
+    protected ProgressIndicatorType $progressType = ProgressIndicatorType::SPINNER;
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('analyze:find-typos')
+            ->setDescription('Detects misspellings in filenames and source code using Peck.')
+            ->setHelp('Usage: vendor/bin/syntra analyze:find-typos');
+    }
+
+    public function perform(): int
+    {
+        $projectRoot = Config::getProjectRoot();
+
+        $kernel = Kernel::default();
+
+        $this->setProgressMax(0); // spinner
+        $this->startProgress();
+        $this->progressIndicator->setMessage('Scanning for typos...');
+
+        $issues = $kernel->handle([
+            'directory' => $projectRoot,
+            'onSuccess' => fn () => $this->advanceProgress(),
+            'onFailure' => fn () => $this->advanceProgress(),
+        ]);
+
+        $this->finishProgress();
+
+        if ($issues === []) {
+            $this->output->success('No misspellings found.');
+            return Command::SUCCESS;
+        }
+
+        $rows = array_map(
+            static function (\Peck\ValueObjects\Issue $issue) use ($projectRoot): array {
+                $file = File::makeRelative($issue->file, $projectRoot);
+                $line = $issue->line > 0 ? (string) $issue->line : '-';
+                $suggestions = implode(', ', $issue->misspelling->suggestions);
+
+                return [$file, $line, $issue->misspelling->word, $suggestions];
+            },
+            $issues,
+        );
+
+        $this->table(['File', 'Line', 'Word', 'Suggestions'], $rows);
+        $this->output->warning(count($rows) . ' misspelling(s) found.');
+
+        return Command::FAILURE;
+    }
+}

--- a/src/Commands/Analyze/FindTyposCommand.php
+++ b/src/Commands/Analyze/FindTyposCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands\Analyze;
 
 use Peck\Kernel;
+use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
@@ -28,6 +29,10 @@ class FindTyposCommand extends SyntraCommand
     public function perform(): int
     {
         $projectRoot = Config::getProjectRoot();
+        $finder = new ExecutableFinder();
+        if ($finder->find('aspell') === null) {
+            throw new \Vix\Syntra\Exceptions\MissingBinaryException('aspell');
+        }
 
         $kernel = Kernel::default();
 

--- a/tests/Commands/FindTyposCommandTest.php
+++ b/tests/Commands/FindTyposCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+
+class FindTyposCommandTest extends TestCase
+{
+    public function testDetectsTypos(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_typo_' . uniqid();
+        mkdir($dir);
+        file_put_contents("$dir/teh_file.php", "<?php\n");
+
+        $app = new Application();
+        File::clearCache();
+        Config::setContainer($app->getContainer());
+        Config::setProjectRoot($dir);
+
+        $command = $app->find('analyze:find-typos');
+        $tester = new CommandTester($command);
+        $tester->execute(['path' => $dir, '--no-progress' => true]);
+
+        $display = $tester->getDisplay();
+
+        $this->assertStringContainsString('teh', $display);
+
+        unlink("$dir/teh_file.php");
+        rmdir($dir);
+    }
+}

--- a/tests/Commands/FindTyposCommandTest.php
+++ b/tests/Commands/FindTyposCommandTest.php
@@ -4,6 +4,7 @@ namespace Vix\Syntra\Tests\Commands;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\ExecutableFinder;
 use Vix\Syntra\Application;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\File;
@@ -12,6 +13,11 @@ class FindTyposCommandTest extends TestCase
 {
     public function testDetectsTypos(): void
     {
+        $finder = new ExecutableFinder();
+        if ($finder->find('aspell') === null) {
+            $this->markTestSkipped('Aspell not installed.');
+        }
+
         $dir = sys_get_temp_dir() . '/syntra_typo_' . uniqid();
         mkdir($dir);
         file_put_contents("$dir/teh_file.php", "<?php\n");


### PR DESCRIPTION
## Summary
- integrate `peckphp/peck` for spell checking
- add new `analyze:find-typos` command
- register command in default config
- document typo detection in README
- add regression test for typo detection

## Testing
- `vendor/bin/phpunit --stop-on-failure`