### PR TITLE
Add init command for project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ composer require vix/syntra
     composer require vix/syntra
     ```
 
-2. **Run your first health check**:
+2. **Initialize Syntra**:
+
+    ```bash
+    vendor/bin/syntra general:init
+    ```
+
+3. **Run your first health check**:
 
     ```bash
     vendor/bin/syntra health:all
     ```
 
-3. **Explore available commands**:
+4. **Explore available commands**:
 
     ```bash
     vendor/bin/syntra list

--- a/config.php
+++ b/config.php
@@ -162,6 +162,10 @@ return [
             'enabled' => true,
             'web_enabled' => true,
         ],
+        \Vix\Syntra\Commands\General\InitCommand::class => [
+            'enabled' => true,
+            'web_enabled' => true,
+        ],
     ],
     CommandGroup::YII->value => [
         YiiAllCommand::class => [

--- a/src/Commands/General/InitCommand.php
+++ b/src/Commands/General/InitCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Commands\General;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Vix\Syntra\Commands\SyntraCommand;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Installer;
+
+class InitCommand extends SyntraCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('general:init')
+            ->setDescription('Initializes Syntra by installing optional packages and copying configuration files.')
+            ->setHelp('Usage: vendor/bin/syntra general:init');
+    }
+
+    public function perform(): int
+    {
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+
+        $packages = [
+            'rector/rector' => 'Rector (code refactoring)',
+            'friendsofphp/php-cs-fixer' => 'PHP CS Fixer (code style fixes)',
+            'phpstan/phpstan' => 'PHPStan (static analysis)',
+            'phpunit/phpunit' => 'PHPUnit (running tests)',
+        ];
+
+        foreach ($packages as $pkg => $desc) {
+            $question = new ConfirmationQuestion(
+                "Install $pkg - $desc? (y/N): ",
+                false,
+                '/^(y|yes)/i'
+            );
+
+            if ($helper->ask($this->input, $this->output, $question)) {
+                $result = Installer::install("composer require --dev $pkg");
+                $this->handleResult($result, "$pkg installation finished.");
+            }
+        }
+
+        $projectRoot = Config::getProjectRoot();
+        $files = [
+            'config.php',
+            'config/php_cs_fixer.php',
+            'config/phpstan.neon',
+            'config/rector.php',
+            'config/rector_only_custom.php',
+        ];
+
+        foreach ($files as $rel) {
+            $src = PACKAGE_ROOT . '/' . $rel;
+            $dest = $projectRoot . '/' . $rel;
+
+            if (!file_exists($dest) && file_exists($src)) {
+                if (!is_dir(dirname($dest))) {
+                    mkdir(dirname($dest), 0777, true);
+                }
+                copy($src, $dest);
+                $display = File::makeRelative($dest, $projectRoot);
+                $this->output->writeln("Created $display");
+            }
+        }
+
+        $this->output->success('Syntra initialization completed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Commands/InitCommandTest.php
+++ b/tests/Commands/InitCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Commands\General\InitCommand;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Utils\PackageInstaller;
+use Vix\Syntra\Tests\Fixtures\DummyInstaller;
+
+class InitCommandTest extends TestCase
+{
+    private function createApp(string $dir, DummyInstaller $installer): Application
+    {
+        $app = new Application();
+        File::clearCache();
+        Config::setContainer($app->getContainer());
+        Config::setProjectRoot($dir);
+
+        $container = $app->getContainer();
+        $container->instance(PackageInstaller::class, $installer);
+        Facade::setContainer($container);
+
+        $cmd = new InitCommand();
+        $app->add($cmd);
+
+        return $app;
+    }
+
+    public function testCopiesConfigFiles(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($dir);
+
+        $installer = new DummyInstaller();
+        $app = $this->createApp($dir, $installer);
+
+        $command = $app->find('general:init');
+        $tester = new CommandTester($command);
+        $tester->setInputs(['no', 'no', 'no', 'no']);
+        $tester->execute(['path' => $dir]);
+
+        $this->assertFileExists("$dir/config.php");
+        $this->assertFileExists("$dir/config/php_cs_fixer.php");
+        $this->assertFileExists("$dir/config/phpstan.neon");
+        $this->assertFileExists("$dir/config/rector.php");
+        $this->assertFileExists("$dir/config/rector_only_custom.php");
+
+        // cleanup
+        unlink("$dir/config.php");
+        unlink("$dir/config/php_cs_fixer.php");
+        unlink("$dir/config/phpstan.neon");
+        unlink("$dir/config/rector.php");
+        unlink("$dir/config/rector_only_custom.php");
+        rmdir("$dir/config");
+        rmdir($dir);
+    }
+
+    public function testInstallsSelectedPackages(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($dir);
+
+        $installer = new DummyInstaller();
+        $app = $this->createApp($dir, $installer);
+
+        $command = $app->find('general:init');
+        $tester = new CommandTester($command);
+        $tester->setInputs(['yes', 'no', 'yes', 'no']);
+        $tester->execute(['path' => $dir]);
+
+        $this->assertSame([
+            'composer require --dev rector/rector',
+            'composer require --dev phpstan/phpstan',
+        ], $installer->commands);
+
+        // cleanup
+        unlink("$dir/config.php");
+        unlink("$dir/config/php_cs_fixer.php");
+        unlink("$dir/config/phpstan.neon");
+        unlink("$dir/config/rector.php");
+        unlink("$dir/config/rector_only_custom.php");
+        rmdir("$dir/config");
+        rmdir($dir);
+    }
+}

--- a/tests/Fixtures/DummyInstaller.php
+++ b/tests/Fixtures/DummyInstaller.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Tests\Fixtures;
+
+use Vix\Syntra\DTO\CommandResult;
+use Vix\Syntra\Utils\PackageInstaller;
+
+class DummyInstaller extends PackageInstaller
+{
+    /** @var string[] */
+    public array $commands = [];
+
+    public function install(string $command): CommandResult
+    {
+        $this->commands[] = $command;
+        return CommandResult::ok(['done']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `InitCommand` to install optional tools and copy config templates
- register `general:init` in configuration and document in README
- provide test coverage for initialization

## Testing
- `vendor/bin/phpunit tests/Commands/InitCommandTest.php --testdox`
- `vendor/bin/phpunit --testdox`