### PR TITLE
Centralize prettyPrintNode in base visitor

### DIFF
--- a/src/NodeVisitors/AssignmentInConditionVisitor.php
+++ b/src/NodeVisitors/AssignmentInConditionVisitor.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\While_;
-use PhpParser\PrettyPrinter\Standard;
 
 class AssignmentInConditionVisitor extends NodeVisitor
 {
@@ -56,8 +55,4 @@ class AssignmentInConditionVisitor extends NodeVisitor
         return $assignments;
     }
 
-    private function prettyPrintNode(Expr $node): string
-    {
-        return (new Standard())->prettyPrintExpr($node);
-    }
 }

--- a/src/NodeVisitors/NestedTernaryVisitor.php
+++ b/src/NodeVisitors/NestedTernaryVisitor.php
@@ -7,7 +7,6 @@ namespace Vix\Syntra\NodeVisitors;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Ternary;
-use PhpParser\PrettyPrinter\Standard;
 
 class NestedTernaryVisitor extends NodeVisitor
 {
@@ -28,8 +27,4 @@ class NestedTernaryVisitor extends NodeVisitor
         return null;
     }
 
-    private function prettyPrintNode(Expr $node): string
-    {
-        return (new Standard())->prettyPrintExpr($node);
-    }
 }

--- a/src/NodeVisitors/NodeVisitor.php
+++ b/src/NodeVisitors/NodeVisitor.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\NodeVisitors;
 
+use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter\Standard;
 
 class NodeVisitor extends NodeVisitorAbstract
 {
     protected array $results = [];
+
+    protected function prettyPrintNode(Node $node): string
+    {
+        $printer = new Standard();
+
+        if ($node instanceof Expr) {
+            return $printer->prettyPrintExpr($node);
+        }
+
+        return $printer->prettyPrint([$node]);
+    }
 
     public function getResults(): array
     {

--- a/src/NodeVisitors/ReturnThrowVisitor.php
+++ b/src/NodeVisitors/ReturnThrowVisitor.php
@@ -7,7 +7,6 @@ namespace Vix\Syntra\NodeVisitors;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Stmt\Return_;
-use PhpParser\PrettyPrinter\Standard;
 
 class ReturnThrowVisitor extends NodeVisitor
 {
@@ -27,8 +26,4 @@ class ReturnThrowVisitor extends NodeVisitor
         return null;
     }
 
-    private function prettyPrintNode($node): string
-    {
-        return (new Standard())->prettyPrintExpr($node);
-    }
 }


### PR DESCRIPTION
## Summary
- add protected prettyPrintNode method to NodeVisitor
- remove redundant prettyPrintNode implementations from visitors
- rely on the inherited method in visitor classes

## Testing
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure`