### PR TITLE
Replace static properties with constants

### DIFF
--- a/src/Commands/Analyze/FindDebugCallsCommand.php
+++ b/src/Commands/Analyze/FindDebugCallsCommand.php
@@ -13,7 +13,7 @@ class FindDebugCallsCommand extends SyntraCommand
 {
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
-    protected static array $DEBUG_FUNCTIONS = [
+    private const DEBUG_FUNCTIONS = [
         'var_dump',
         'print_r',
         'dd',
@@ -41,7 +41,7 @@ class FindDebugCallsCommand extends SyntraCommand
         $files = File::collectFiles($this->path);
 
         $matches = [];
-        $pattern = '/(?<![\w\$])(' . implode('|', array_map('preg_quote', self::$DEBUG_FUNCTIONS)) . ')\s*\(/i';
+        $pattern = '/(?<![\w\$])(' . implode('|', array_map('preg_quote', self::DEBUG_FUNCTIONS)) . ')\s*\(/i';
 
         $this->setProgressMax(count($files));
         $this->startProgress();

--- a/src/Commands/Analyze/FindTodosCommand.php
+++ b/src/Commands/Analyze/FindTodosCommand.php
@@ -13,7 +13,7 @@ class FindTodosCommand extends SyntraCommand
 {
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
-    protected static array $TAGS = [
+    private const TAGS = [
         'TODO',
         'FIXME',
         '@todo',
@@ -40,7 +40,7 @@ class FindTodosCommand extends SyntraCommand
         $files = File::collectFiles($this->path);
 
         $matches = [];
-        $allTags = implode('|', array_map('preg_quote', self::$TAGS));
+        $allTags = implode('|', array_map('preg_quote', self::TAGS));
         $pattern = "/(?:\/\/|#|\*|\s)\s*($allTags)\b(.*)/i";
 
         $this->setProgressMax(count($files));


### PR DESCRIPTION
## Summary
- refactor debug/todo arrays in analyzer commands to use `private const`
- update usage of arrays

## Testing
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_686daca7cf348322b59d524cfc828a57