### PR TITLE
Handle empty Rector rule list

### DIFF
--- a/src/Utils/RectorCommandExecutor.php
+++ b/src/Utils/RectorCommandExecutor.php
@@ -26,12 +26,18 @@ class RectorCommandExecutor
      * @param string[] $rectorClasses  Rector rule class name(s)
      * @param array    $additionalArgs Additional arguments to pass to Rector
      *
-     * @return ProcessResult The result of the last executed rule
+     * @return ProcessResult The result of the last executed rule. If no rules
+     *                        are provided, a successful empty result is returned.
      *
      * @throws MissingBinaryException
      */
     public function executeRules(string $path, array $rectorClasses, array $additionalArgs = [], ?callable $outputCallback = null): ProcessResult
     {
+        if ($rectorClasses === []) {
+            // No rules to execute, return a successful default result
+            return new ProcessResult(0, '', '');
+        }
+
         $this->findBinaryTool(new RectorTool());
         $result = null;
 

--- a/tests/Utils/RectorCommandExecutorTest.php
+++ b/tests/Utils/RectorCommandExecutorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Vix\Syntra\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Application;
+use Vix\Syntra\DTO\ProcessResult;
+use Vix\Syntra\Utils\RectorCommandExecutor;
+
+class RectorCommandExecutorTest extends TestCase
+{
+    public function testReturnsDefaultResultWhenNoRulesProvided(): void
+    {
+        new Application();
+        $executor = new RectorCommandExecutor();
+
+        $result = $executor->executeRules(sys_get_temp_dir(), []);
+
+        $this->assertInstanceOf(ProcessResult::class, $result);
+        $this->assertSame(0, $result->exitCode);
+        $this->assertSame('', $result->output);
+        $this->assertSame('', $result->stderr);
+    }
+}
+


### PR DESCRIPTION
## Summary
- avoid null return from `RectorCommandExecutor::executeRules`
- add regression test for empty rules

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse src tests --error-format=table` *(fails: Found 39 errors)*