### PR TITLE
Refactor analyze commands with AnalyzesFilesTrait

### DIFF
--- a/src/Commands/Analyze/FindBadPracticesCommand.php
+++ b/src/Commands/Analyze/FindBadPracticesCommand.php
@@ -15,10 +15,12 @@ use Vix\Syntra\Facades\File;
 use Vix\Syntra\NodeVisitors\AssignmentInConditionVisitor;
 use Vix\Syntra\NodeVisitors\NestedTernaryVisitor;
 use Vix\Syntra\Traits\ContainerAwareTrait;
+use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class FindBadPracticesCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
+    use AnalyzesFilesTrait;
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
@@ -36,22 +38,17 @@ class FindBadPracticesCommand extends SyntraCommand
     {
         $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
-        $files = File::collectFiles($this->path);
-
-        $this->setProgressMax(count($files));
-        $this->startProgress();
-
         $rows = [];
-        foreach ($files as $file) {
+        $this->analyzeFiles(function (string $file) use (&$rows, $parser): void {
             $code = file_get_contents($file);
             if ($code === false) {
-                continue;
+                return;
             }
 
             try {
                 $ast = $parser->parse($code);
             } catch (Throwable) {
-                continue;
+                return;
             }
 
             $visitors = [];
@@ -83,11 +80,7 @@ class FindBadPracticesCommand extends SyntraCommand
                     ];
                 }
             }
-
-            $this->advanceProgress();
-        }
-
-        $this->finishProgress();
+        });
 
         if (empty($rows)) {
             $this->output->success("All good. 👍");

--- a/src/Commands/Analyze/FindDebugCallsCommand.php
+++ b/src/Commands/Analyze/FindDebugCallsCommand.php
@@ -8,9 +8,12 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class FindDebugCallsCommand extends SyntraCommand
 {
+    use AnalyzesFilesTrait;
+
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected static array $DEBUG_FUNCTIONS = [
@@ -38,22 +41,17 @@ class FindDebugCallsCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $files = File::collectFiles($this->path);
-
         $matches = [];
         $pattern = '/(?<![\w\$])(' . implode('|', array_map('preg_quote', self::$DEBUG_FUNCTIONS)) . ')\s*\(/i';
 
-        $this->setProgressMax(count($files));
-        $this->startProgress();
-
-        foreach ($files as $filePath) {
-            if (str_contains((string) $filePath, "FindDebugCallsCommand")) {
-                continue;
+        $this->analyzeFiles(function (string $filePath) use (&$matches, $pattern): void {
+            if (str_contains((string) $filePath, 'FindDebugCallsCommand')) {
+                return;
             }
 
             $content = file_get_contents($filePath);
             if ($content === false) {
-                continue;
+                return;
             }
 
             $relativePath = File::makeRelative($filePath, $this->path);
@@ -69,11 +67,7 @@ class FindDebugCallsCommand extends SyntraCommand
                     ];
                 }
             }
-
-            $this->advanceProgress();
-        }
-
-        $this->finishProgress();
+        });
 
         if (!$matches) {
             $this->output->success('No debug calls or comments found! Code is clean 👌');

--- a/src/Commands/Analyze/StrictTypesCoverageCommand.php
+++ b/src/Commands/Analyze/StrictTypesCoverageCommand.php
@@ -8,9 +8,12 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class StrictTypesCoverageCommand extends SyntraCommand
 {
+    use AnalyzesFilesTrait;
+
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
     protected function configure(): void
@@ -25,23 +28,17 @@ class StrictTypesCoverageCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $files = File::collectFiles($this->path);
+        $files = $this->collectFiles();
 
         $total = count($files);
         $withStrict = 0;
 
-        $this->setProgressMax($total);
-        $this->startProgress();
-
-        foreach ($files as $file) {
+        $this->iterateFiles($files, function (string $file) use (&$withStrict): void {
             $content = file_get_contents($file);
             if ($content !== false && preg_match('/^\s*<\?php\s+declare\(strict_types=1\);/m', $content)) {
                 $withStrict++;
             }
-            $this->advanceProgress();
-        }
-
-        $this->finishProgress();
+        });
 
         $coverage = $total > 0 ? round($withStrict / $total * 100, 2) : 100.0;
         $this->output->writeln(sprintf('Strict types coverage: %d/%d (%.1f%%)', $withStrict, $total, $coverage));

--- a/src/Traits/AnalyzesFilesTrait.php
+++ b/src/Traits/AnalyzesFilesTrait.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Traits;
+
+use Vix\Syntra\Facades\File;
+
+/**
+ * Provides helper methods for analyze commands that work with project files.
+ */
+trait AnalyzesFilesTrait
+{
+    /**
+     * Collect all PHP files within the current path.
+     *
+     * @return string[]
+     */
+    protected function collectFiles(): array
+    {
+        return File::collectFiles($this->path);
+    }
+
+    /**
+     * Collect files and iterate over them with progress feedback.
+     *
+     * @param callable(string):void $callback
+     */
+    protected function analyzeFiles(callable $callback): void
+    {
+        $files = $this->collectFiles();
+        $this->iterateFiles($files, $callback);
+    }
+
+    /**
+     * Iterate over the given files with progress indicators.
+     *
+     * @param string[]               $files
+     * @param callable(string):void  $callback
+     */
+    protected function iterateFiles(array $files, callable $callback): void
+    {
+        $this->setProgressMax(count($files));
+        $this->startProgress();
+
+        foreach ($files as $file) {
+            $callback($file);
+            $this->advanceProgress();
+        }
+
+        $this->finishProgress();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AnalyzesFilesTrait` with helpers to collect files and run analysis loops
- refactor all analyze commands to use this trait

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686dac92591c8322bcf3cd6e24acdc90