### PR TITLE
Refactor container service access

### DIFF
--- a/src/Commands/Analyze/FindBadPracticesCommand.php
+++ b/src/Commands/Analyze/FindBadPracticesCommand.php
@@ -35,7 +35,7 @@ class FindBadPracticesCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
+        $parser = $this->resolveService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
         $rows = [];
         $this->analyzeFiles(function (string $file) use (&$rows, $parser): void {

--- a/src/Commands/Analyze/FindLongMethodsCommand.php
+++ b/src/Commands/Analyze/FindLongMethodsCommand.php
@@ -36,7 +36,7 @@ class FindLongMethodsCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
+        $parser = $this->resolveService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
         $maxLength = (int) $this->input->getOption('max');
 

--- a/src/Commands/General/GenerateDocsCommand.php
+++ b/src/Commands/General/GenerateDocsCommand.php
@@ -55,7 +55,7 @@ class GenerateDocsCommand extends SyntraCommand
         $controllerDirOption = $this->input->getOption('controller-dir');
         $controllerDir = $rootPath . '/' . ltrim((string) ($controllerDirOption ?? 'backend/controllers'), '/');
 
-        $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
+        $parser = $this->resolveService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
         $routes = [];
 

--- a/src/Traits/ContainerAwareTrait.php
+++ b/src/Traits/ContainerAwareTrait.php
@@ -30,36 +30,14 @@ trait ContainerAwareTrait
     }
 
     /**
-     * Get a service from the container with fallback
+     * Resolve a service from the container with an optional fallback
      *
      * @template T of object
      * @param  class-string<T> $id       Service identifier
-     * @param  callable|null   $fallback Function to create service if container unavailable
-     * @return T
+     * @param  callable|null  $fallback Function to create service if container unavailable
+     * @return T|mixed
      */
-    protected function getService(string $id, ?callable $fallback = null): object
-    {
-        $container = $this->getContainer();
-
-        if ($container !== null && $container->has($id)) {
-            return $container->get($id);
-        }
-
-        if ($fallback !== null) {
-            return $fallback();
-        }
-
-        throw new RuntimeException("Service '$id' not available and no fallback provided");
-    }
-
-    /**
-     * Get a named service from the container with fallback
-     *
-     * @param  string        $id       Service identifier
-     * @param  callable|null $fallback Function to create service if container unavailable
-     * @return mixed
-     */
-    protected function getNamedService(string $id, ?callable $fallback = null): mixed
+    protected function resolveService(string $id, ?callable $fallback = null): mixed
     {
         $container = $this->getContainer();
 


### PR DESCRIPTION
## Summary
- collapse service helpers into `resolveService()`
- use `resolveService()` across commands
- remove deprecated service helpers

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse src tests -c config/phpstan.neon`