### PR TITLE
Move debug lists into command config

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ return [
 
 The PHPStan health check reads from `config/phpstan.neon` by default, so tweak that file to customize analysis settings.
 
+You can customize the list of debug function names or TODO tags by editing the `debug_functions` and `todo_tags` arrays for their commands in `config.php`.
+
 ## 💡 Tips & Best Practices
 
 ### Safety First

--- a/config.php
+++ b/config.php
@@ -112,9 +112,32 @@ return [
         ],
         FindTodosCommand::class => [
             'enabled' => true,
+            'todo_tags' => [
+                'TODO',
+                'FIXME',
+                '@todo',
+                '@fixme',
+                '@deprecated',
+                '@note',
+                // '@see',
+                '@hack',
+                '@internal',
+            ],
         ],
         FindDebugCallsCommand::class => [
             'enabled' => true,
+            'debug_functions' => [
+                'var_dump',
+                'print_r',
+                'dd',
+                'dump',
+                'ray',
+                'die',
+                'exit',
+                'logger(',
+                'eval',
+                'xdebug_break',
+            ],
         ],
         FindLongMethodsCommand::class => [
             'enabled' => true,

--- a/src/Commands/Analyze/FindTodosCommand.php
+++ b/src/Commands/Analyze/FindTodosCommand.php
@@ -8,6 +8,8 @@ use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Enums\CommandGroup;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class FindTodosCommand extends SyntraCommand
@@ -16,17 +18,6 @@ class FindTodosCommand extends SyntraCommand
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
-    private const TAGS = [
-        'TODO',
-        'FIXME',
-        '@todo',
-        '@fixme',
-        '@deprecated',
-        '@note',
-        // '@see',
-        '@hack',
-        '@internal',
-    ];
 
     protected function configure(): void
     {
@@ -41,7 +32,23 @@ class FindTodosCommand extends SyntraCommand
     public function perform(): int
     {
         $matches = [];
-        $allTags = implode('|', array_map('preg_quote', self::TAGS));
+        $tags = Config::getCommandOption(
+            CommandGroup::ANALYZE->value,
+            self::class,
+            'todo_tags',
+            [
+                'TODO',
+                'FIXME',
+                '@todo',
+                '@fixme',
+                '@deprecated',
+                '@note',
+                // '@see',
+                '@hack',
+                '@internal',
+            ]
+        );
+        $allTags = implode('|', array_map('preg_quote', $tags));
         $pattern = "/(?:\/\/|#|\*|\s)\s*($allTags)\b(.*)/i";
 
         $this->analyzeFiles(function (string $filePath) use (&$matches, $pattern): void {

--- a/src/Commands/Health/EditorConfigCheckCommand.php
+++ b/src/Commands/Health/EditorConfigCheckCommand.php
@@ -16,32 +16,6 @@ class EditorConfigCheckCommand extends AbstractHealthCommand
     protected string $sectionTitle = 'Checking for .editorconfig...';
     protected string $successMessage = '.editorconfig check completed.';
 
-    private const DEFAULT_CONFIG = <<<'CFG'
-    root = true
-
-    [*]
-    charset = utf-8
-    end_of_line = lf
-    indent_size = 4
-    indent_style = space
-    insert_final_newline = true
-    trim_trailing_whitespace = true
-
-    [*.md]
-    trim_trailing_whitespace = false
-
-    [*.{yml,yaml}]
-    indent_size = 2
-
-    [docker-compose.yml]
-    indent_size = 2
-
-    [*.php]
-    indent_style = space
-    indent_size = 4
-    insert_final_newline = true
-    trim_trailing_whitespace = true
-    CFG;
 
     protected function configure(): void
     {
@@ -68,7 +42,13 @@ class EditorConfigCheckCommand extends AbstractHealthCommand
     {
         if ($result->status === CommandStatus::WARNING && $this->input->getOption('generate')) {
             $path = Project::getRootPath() . '/.editorconfig';
-            file_put_contents($path, self::DEFAULT_CONFIG . "\n");
+            $stubPath = PACKAGE_ROOT . '/stubs/editorconfig.stub';
+            if (is_file($stubPath)) {
+                $content = file_get_contents($stubPath);
+                if ($content !== false) {
+                    file_put_contents($path, $content);
+                }
+            }
             $this->output->success('.editorconfig file generated.');
             return Command::SUCCESS;
         }

--- a/stubs/editorconfig.stub
+++ b/stubs/editorconfig.stub
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[docker-compose.yml]
+indent_size = 2
+
+[*.php]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -3,13 +3,13 @@
 namespace Vix\Syntra\Tests\Commands;
 
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 use Symfony\Component\Console\Tester\CommandTester;
 use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Facade;
+use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ConfigLoader;
 
@@ -60,6 +60,7 @@ class EditorConfigCheckCommandTest extends TestCase
         mkdir($dir);
 
         $app = new Application();
+        Config::setContainer($app->getContainer());
         Project::setRootPath($dir);
 
         $command = $app->find('health:editorconfig');
@@ -67,8 +68,7 @@ class EditorConfigCheckCommandTest extends TestCase
         $tester->execute(['path' => $dir, '--generate' => true]);
 
         $this->assertFileExists("$dir/.editorconfig");
-        $ref = new ReflectionClass(EditorConfigCheckCommand::class);
-        $expected = trim((string) $ref->getConstant('DEFAULT_CONFIG'));
+        $expected = trim((string) file_get_contents(PACKAGE_ROOT . '/stubs/editorconfig.stub'));
         $actual = trim((string) file_get_contents("$dir/.editorconfig"));
         $this->assertSame($expected, $actual);
 


### PR DESCRIPTION
## Summary
- store default debug function names and todo tags under each command in `config.php`
- generate `.editorconfig` from a new stub file
- drop now-unused `config/syntra.php` and related loader methods
- adjust commands and tests to read options from command config or stub
- update README

## Testing
- `./vendor/bin/phpunit`