### PR TITLE
Add PHP AST parsing helper and tests

### DIFF
--- a/src/Commands/Analyze/FindBadPracticesCommand.php
+++ b/src/Commands/Analyze/FindBadPracticesCommand.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands\Analyze;
 
 use PhpParser\NodeTraverser;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 use Symfony\Component\Console\Command\Command;
-use Throwable;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\NodeVisitors\AssignmentInConditionVisitor;
 use Vix\Syntra\NodeVisitors\NestedTernaryVisitor;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
 use Vix\Syntra\Traits\ContainerAwareTrait;
+use Vix\Syntra\Traits\ParsesPhpFilesTrait;
 
 class FindBadPracticesCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
     use AnalyzesFilesTrait;
+    use ParsesPhpFilesTrait;
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
@@ -35,40 +34,24 @@ class FindBadPracticesCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
-
         $rows = [];
-        $this->analyzeFiles(function (string $file) use (&$rows, $parser): void {
-            $code = file_get_contents($file);
-            if ($code === false) {
-                return;
-            }
-
-            try {
-                $ast = $parser->parse($code);
-            } catch (Throwable) {
-                return;
-            }
-
+        $this->analyzeFiles(function (string $file) use (&$rows): void {
             $visitors = [];
-            $traverser = new NodeTraverser();
 
-            // Use visitor classes through DI
-            $visitorClasses = [
-                NestedTernaryVisitor::class,
-                AssignmentInConditionVisitor::class,
-                // ReturnThrowVisitor::class,
-            ];
+            $this->parseFile($file, function (NodeTraverser $traverser) use (&$visitors): void {
+                $visitorClasses = [
+                    NestedTernaryVisitor::class,
+                    AssignmentInConditionVisitor::class,
+                    // ReturnThrowVisitor::class,
+                ];
 
-            foreach ($visitorClasses as $visitorClass) {
-                $visitor = new $visitorClass();
-                $visitors[] = $visitor;
-                $traverser->addVisitor($visitor);
-            }
+                foreach ($visitorClasses as $visitorClass) {
+                    $visitor = new $visitorClass();
+                    $visitors[] = $visitor;
+                    $traverser->addVisitor($visitor);
+                }
+            });
 
-            $traverser->traverse($ast);
-
-            // Get findings from visitors
             foreach ($visitors as $visitor) {
                 foreach ($visitor->getResults() as $finding) {
                     $rows[] = [

--- a/src/Commands/Analyze/FindDebugCallsCommand.php
+++ b/src/Commands/Analyze/FindDebugCallsCommand.php
@@ -6,10 +6,10 @@ namespace Vix\Syntra\Commands\Analyze;
 
 use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
-use Vix\Syntra\Enums\ProgressIndicatorType;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Enums\CommandGroup;
+use Vix\Syntra\Enums\ProgressIndicatorType;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class FindDebugCallsCommand extends SyntraCommand
@@ -17,7 +17,6 @@ class FindDebugCallsCommand extends SyntraCommand
     use AnalyzesFilesTrait;
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
-
 
     protected function configure(): void
     {

--- a/src/Commands/Analyze/FindLongMethodsCommand.php
+++ b/src/Commands/Analyze/FindLongMethodsCommand.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace Vix\Syntra\Commands\Analyze;
 
 use PhpParser\NodeTraverser;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
-use Throwable;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\NodeVisitors\LongMethodVisitor;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
 use Vix\Syntra\Traits\ContainerAwareTrait;
+use Vix\Syntra\Traits\ParsesPhpFilesTrait;
 
 class FindLongMethodsCommand extends SyntraCommand
 {
     use ContainerAwareTrait;
     use AnalyzesFilesTrait;
+    use ParsesPhpFilesTrait;
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
 
@@ -36,29 +35,15 @@ class FindLongMethodsCommand extends SyntraCommand
 
     public function perform(): int
     {
-        $parser = $this->getService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
-
         $maxLength = (int) $this->input->getOption('max');
 
         $longMethods = [];
 
-        $this->analyzeFiles(function (string $filePath) use (&$longMethods, $maxLength, $parser): void {
-            $code = file_get_contents($filePath);
-            if ($code === false) {
-                return;
-            }
-
-            try {
-                $stmts = $parser->parse($code);
-            } catch (Throwable) {
-                return;
-            }
-
-            $traverser = new NodeTraverser();
-            $visitor = new LongMethodVisitor($filePath, $maxLength, $longMethods);
-
-            $traverser->addVisitor($visitor);
-            $traverser->traverse($stmts);
+        $this->analyzeFiles(function (string $filePath) use (&$longMethods, $maxLength): void {
+            $this->parseFile($filePath, function (NodeTraverser $traverser) use (&$longMethods, $maxLength, $filePath): void {
+                $visitor = new LongMethodVisitor($filePath, $maxLength, $longMethods);
+                $traverser->addVisitor($visitor);
+            });
         });
 
         if (empty($longMethods)) {

--- a/src/Commands/Analyze/FindTodosCommand.php
+++ b/src/Commands/Analyze/FindTodosCommand.php
@@ -6,10 +6,10 @@ namespace Vix\Syntra\Commands\Analyze;
 
 use Symfony\Component\Console\Command\Command;
 use Vix\Syntra\Commands\SyntraCommand;
-use Vix\Syntra\Enums\ProgressIndicatorType;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Enums\CommandGroup;
+use Vix\Syntra\Enums\ProgressIndicatorType;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
 
 class FindTodosCommand extends SyntraCommand
@@ -17,7 +17,6 @@ class FindTodosCommand extends SyntraCommand
     use AnalyzesFilesTrait;
 
     protected ProgressIndicatorType $progressType = ProgressIndicatorType::PROGRESS_BAR;
-
 
     protected function configure(): void
     {

--- a/src/Commands/Health/EditorConfigCheckCommand.php
+++ b/src/Commands/Health/EditorConfigCheckCommand.php
@@ -16,7 +16,6 @@ class EditorConfigCheckCommand extends AbstractHealthCommand
     protected string $sectionTitle = 'Checking for .editorconfig...';
     protected string $successMessage = '.editorconfig check completed.';
 
-
     protected function configure(): void
     {
         parent::configure();

--- a/src/NodeVisitors/AssignmentInConditionVisitor.php
+++ b/src/NodeVisitors/AssignmentInConditionVisitor.php
@@ -54,5 +54,4 @@ class AssignmentInConditionVisitor extends NodeVisitor
 
         return $assignments;
     }
-
 }

--- a/src/NodeVisitors/NestedTernaryVisitor.php
+++ b/src/NodeVisitors/NestedTernaryVisitor.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Vix\Syntra\NodeVisitors;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Ternary;
 
 class NestedTernaryVisitor extends NodeVisitor
@@ -26,5 +25,4 @@ class NestedTernaryVisitor extends NodeVisitor
 
         return null;
     }
-
 }

--- a/src/NodeVisitors/ReturnThrowVisitor.php
+++ b/src/NodeVisitors/ReturnThrowVisitor.php
@@ -25,5 +25,4 @@ class ReturnThrowVisitor extends NodeVisitor
 
         return null;
     }
-
 }

--- a/src/Traits/ContainerAwareTrait.php
+++ b/src/Traits/ContainerAwareTrait.php
@@ -34,7 +34,7 @@ trait ContainerAwareTrait
      *
      * @template T of object
      * @param  class-string<T> $id       Service identifier
-     * @param  callable|null  $fallback Function to create service if container unavailable
+     * @param  callable|null   $fallback Function to create service if container unavailable
      * @return T|mixed
      */
     protected function resolveService(string $id, ?callable $fallback = null): mixed

--- a/src/Traits/ParsesPhpFilesTrait.php
+++ b/src/Traits/ParsesPhpFilesTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Traits;
+
+use PhpParser\NodeTraverser;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use Throwable;
+
+/**
+ * Helper trait to parse a PHP file and traverse its AST.
+ */
+trait ParsesPhpFilesTrait
+{
+    use ContainerAwareTrait;
+
+    /**
+     * Parse the given PHP file and traverse it with custom visitors.
+     *
+     * @param callable(NodeTraverser):void $traverserSetup Callback receiving the traverser to add visitors
+     */
+    protected function parseFile(string $path, callable $traverserSetup): void
+    {
+        $parser = $this->getService(
+            Parser::class,
+            fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
+        );
+
+        $code = file_get_contents($path);
+        if ($code === false) {
+            return;
+        }
+
+        try {
+            $ast = $parser->parse($code);
+        } catch (Throwable) {
+            return;
+        }
+
+        if ($ast === null) {
+            return;
+        }
+
+        $traverser = new NodeTraverser();
+        $traverserSetup($traverser);
+        $traverser->traverse($ast);
+    }
+}

--- a/src/Traits/ParsesPhpFilesTrait.php
+++ b/src/Traits/ParsesPhpFilesTrait.php
@@ -23,10 +23,7 @@ trait ParsesPhpFilesTrait
      */
     protected function parseFile(string $path, callable $traverserSetup): void
     {
-        $parser = $this->getService(
-            Parser::class,
-            fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
-        );
+        $parser = $this->resolveService(Parser::class, fn(): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
         $code = file_get_contents($path);
         if ($code === false) {

--- a/src/Traits/ParsesPhpFilesTrait.php
+++ b/src/Traits/ParsesPhpFilesTrait.php
@@ -23,7 +23,7 @@ trait ParsesPhpFilesTrait
      */
     protected function parseFile(string $path, callable $traverserSetup): void
     {
-        $parser = $this->resolveService(Parser::class, fn(): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
+        $parser = $this->resolveService(Parser::class, fn (): Parser => (new ParserFactory())->create(ParserFactory::PREFER_PHP7));
 
         $code = file_get_contents($path);
         if ($code === false) {

--- a/src/Traits/RunsExternalTool.php
+++ b/src/Traits/RunsExternalTool.php
@@ -17,10 +17,10 @@ trait RunsExternalTool
     /**
      * Run the given tool and display progress.
      *
-     * @param ToolInterface       $tool            Tool used for binary lookup
-     * @param string[]            $args            Arguments passed to the binary
-     * @param string              $successMessage  Message shown on success
-     * @param string              $errorMessage    Message shown on failure
+     * @param ToolInterface $tool           Tool used for binary lookup
+     * @param string[]      $args           Arguments passed to the binary
+     * @param string        $successMessage Message shown on success
+     * @param string        $errorMessage   Message shown on failure
      */
     protected function runTool(ToolInterface $tool, array $args, string $successMessage, string $errorMessage): int
     {

--- a/src/Traits/RunsSubCommandsTrait.php
+++ b/src/Traits/RunsSubCommandsTrait.php
@@ -11,9 +11,9 @@ trait RunsSubCommandsTrait
     /**
      * Run enabled commands filtered by namespace and/or group.
      *
-     * @param string      $namespace Part of the FQCN to filter by.
-     * @param string|null $group     Command group to filter, or null for all.
-     * @param array<string,mixed> $input Input forwarded to each command.
+     * @param string              $namespace Part of the FQCN to filter by.
+     * @param string|null         $group     Command group to filter, or null for all.
+     * @param array<string,mixed> $input     Input forwarded to each command.
      *
      * @return bool True when at least one command returned non-success.
      */

--- a/src/Utils/RectorCommandExecutor.php
+++ b/src/Utils/RectorCommandExecutor.php
@@ -27,7 +27,7 @@ class RectorCommandExecutor
      * @param array    $additionalArgs Additional arguments to pass to Rector
      *
      * @return ProcessResult The result of the last executed rule. If no rules
-     *                        are provided, a successful empty result is returned.
+     *                       are provided, a successful empty result is returned.
      *
      * @throws MissingBinaryException
      */

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -8,8 +8,8 @@ use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
-use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ConfigLoader;
 

--- a/tests/Commands/FindBadPracticesCommandTest.php
+++ b/tests/Commands/FindBadPracticesCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Project;
+
+class FindBadPracticesCommandTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($this->dir);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob("$this->dir/*.php"));
+        rmdir($this->dir);
+    }
+
+    public function testDetectsBadPractices(): void
+    {
+        $code = <<<'PHP'
+<?php
+function foo($a, $b) {
+    return $a ? ($b ? 1 : 2) : 3;
+}
+PHP;
+        file_put_contents("$this->dir/test.php", $code);
+
+        $app = new Application();
+        File::clearCache();
+        Project::setRootPath($this->dir);
+
+        $command = $app->find('analyze:find-bad-practices');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('Nested ternary operator', $tester->getDisplay());
+    }
+}

--- a/tests/Commands/FindLongMethodsCommandTest.php
+++ b/tests/Commands/FindLongMethodsCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Vix\Syntra\Tests\Commands;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Project;
+
+class FindLongMethodsCommandTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($this->dir);
+    }
+
+    protected function tearDown(): void
+    {
+        array_map('unlink', glob("$this->dir/*.php"));
+        rmdir($this->dir);
+    }
+
+    public function testDetectsLongMethod(): void
+    {
+        $body = str_repeat("    \$a = 1;\n", 4);
+        $code = "<?php\nfunction longOne() {\n$body}\n";
+        file_put_contents("$this->dir/test.php", $code);
+
+        $app = new Application();
+        File::clearCache();
+        Project::setRootPath($this->dir);
+
+        $command = $app->find('analyze:find-long-methods');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'path' => $this->dir,
+            '--no-progress' => true,
+            '--max' => 3,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('longOne', $tester->getDisplay());
+    }
+}

--- a/tests/Utils/RectorCommandExecutorTest.php
+++ b/tests/Utils/RectorCommandExecutorTest.php
@@ -22,4 +22,3 @@ class RectorCommandExecutorTest extends TestCase
         $this->assertSame('', $result->stderr);
     }
 }
-


### PR DESCRIPTION
## Summary
- add `ParsesPhpFilesTrait` for shared PHP parser/traverser logic
- refactor `FindBadPracticesCommand` and `FindLongMethodsCommand` to use the new trait
- add tests covering these commands

## Testing
- `./vendor/bin/phpunit --stop-on-failure`