### PR TITLE
Refactor command tests to share setup

### DIFF
--- a/tests/CommandTestCase.php
+++ b/tests/CommandTestCase.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Vix\Syntra\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Vix\Syntra\Application;
+use Vix\Syntra\Facades\Config;
+use Vix\Syntra\Facades\File;
+use Vix\Syntra\Facades\Project;
+
+abstract class CommandTestCase extends TestCase
+{
+    protected Application $app;
+    protected string $dir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
+        mkdir($this->dir, 0777, true);
+
+        $this->app = new Application();
+        File::clearCache();
+        Config::setContainer($this->app->getContainer());
+        Project::setRootPath($this->dir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteDir($this->dir);
+        parent::tearDown();
+    }
+
+    protected function runCommand(string $name, array $input = []): CommandTester
+    {
+        $command = $this->app->find($name);
+        $tester = new CommandTester($command);
+        $tester->execute($input);
+        return $tester;
+    }
+
+    private function deleteDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Commands/DangerLevelWarningTest.php
+++ b/tests/Commands/DangerLevelWarningTest.php
@@ -2,21 +2,16 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraRefactorCommand;
 use Vix\Syntra\Enums\DangerLevel;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class DangerLevelWarningTest extends TestCase
+class DangerLevelWarningTest extends CommandTestCase
 {
     public function testWarningShownForHighDanger(): void
     {
-        $app = new Application();
-        Project::setRootPath(sys_get_temp_dir());
-
         $command = new class () extends SyntraRefactorCommand {
             protected DangerLevel $dangerLevel = DangerLevel::HIGH;
 
@@ -33,7 +28,7 @@ class DangerLevelWarningTest extends TestCase
             }
         };
 
-        $app->add($command);
+        $this->app->add($command);
         $tester = new CommandTester($command);
         $tester->execute([]);
 

--- a/tests/Commands/EditorConfigCheckCommandTest.php
+++ b/tests/Commands/EditorConfigCheckCommandTest.php
@@ -2,10 +2,9 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Health\EditorConfigCheckCommand;
+use Vix\Syntra\Tests\CommandTestCase;
 use Vix\Syntra\DI\Container;
 use Vix\Syntra\Enums\CommandStatus;
 use Vix\Syntra\Facades\Config;
@@ -13,7 +12,7 @@ use Vix\Syntra\Facades\Facade;
 use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Utils\ConfigLoader;
 
-class EditorConfigCheckCommandTest extends TestCase
+class EditorConfigCheckCommandTest extends CommandTestCase
 {
     private function makeCommand(string $root): EditorConfigCheckCommand
     {
@@ -56,23 +55,13 @@ class EditorConfigCheckCommandTest extends TestCase
 
     public function testGenerateOptionCreatesFile(): void
     {
-        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
-        mkdir($dir);
-
-        $app = new Application();
-        Config::setContainer($app->getContainer());
-        Project::setRootPath($dir);
-
-        $command = $app->find('health:editorconfig');
+        $command = $this->app->find('health:editorconfig');
         $tester = new CommandTester($command);
-        $tester->execute(['path' => $dir, '--generate' => true]);
+        $tester->execute(['path' => $this->dir, '--generate' => true]);
 
-        $this->assertFileExists("$dir/.editorconfig");
+        $this->assertFileExists("$this->dir/.editorconfig");
         $expected = trim((string) file_get_contents(PACKAGE_ROOT . '/stubs/editorconfig.stub'));
-        $actual = trim((string) file_get_contents("$dir/.editorconfig"));
+        $actual = trim((string) file_get_contents("$this->dir/.editorconfig"));
         $this->assertSame($expected, $actual);
-
-        unlink("$dir/.editorconfig");
-        rmdir($dir);
     }
 }

--- a/tests/Commands/FailOnWarningTest.php
+++ b/tests/Commands/FailOnWarningTest.php
@@ -2,16 +2,14 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\DTO\CommandResult;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 use Vix\Syntra\Traits\HandlesResultTrait;
 
-class FailOnWarningTest extends TestCase
+class FailOnWarningTest extends CommandTestCase
 {
     private function makeCommand(): SyntraCommand
     {
@@ -34,11 +32,8 @@ class FailOnWarningTest extends TestCase
 
     public function testFailOnWarningOption(): void
     {
-        $app = new Application();
-        Project::setRootPath(sys_get_temp_dir());
-
         $command = $this->makeCommand();
-        $app->add($command);
+        $this->app->add($command);
         $tester = new CommandTester($command);
 
         $tester->execute(['--fail-on-warning' => true]);
@@ -48,11 +43,8 @@ class FailOnWarningTest extends TestCase
 
     public function testCiModeFailsOnWarning(): void
     {
-        $app = new Application();
-        Project::setRootPath(sys_get_temp_dir());
-
         $command = $this->makeCommand();
-        $app->add($command);
+        $this->app->add($command);
         $tester = new CommandTester($command);
 
         $tester->execute(['--ci' => true]);

--- a/tests/Commands/FindBadPracticesCommandTest.php
+++ b/tests/Commands/FindBadPracticesCommandTest.php
@@ -2,28 +2,12 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class FindBadPracticesCommandTest extends TestCase
+class FindBadPracticesCommandTest extends CommandTestCase
 {
-    private string $dir;
-
-    protected function setUp(): void
-    {
-        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
-        mkdir($this->dir);
-    }
-
-    protected function tearDown(): void
-    {
-        array_map('unlink', glob("$this->dir/*.php"));
-        rmdir($this->dir);
-    }
 
     public function testDetectsBadPractices(): void
     {
@@ -35,13 +19,7 @@ function foo($a, $b) {
 PHP;
         file_put_contents("$this->dir/test.php", $code);
 
-        $app = new Application();
-        File::clearCache();
-        Project::setRootPath($this->dir);
-
-        $command = $app->find('analyze:find-bad-practices');
-        $tester = new CommandTester($command);
-        $tester->execute([
+        $tester = $this->runCommand('analyze:find-bad-practices', [
             'path' => $this->dir,
             '--no-progress' => true,
         ]);

--- a/tests/Commands/FindLongMethodsCommandTest.php
+++ b/tests/Commands/FindLongMethodsCommandTest.php
@@ -2,28 +2,12 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class FindLongMethodsCommandTest extends TestCase
+class FindLongMethodsCommandTest extends CommandTestCase
 {
-    private string $dir;
-
-    protected function setUp(): void
-    {
-        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
-        mkdir($this->dir);
-    }
-
-    protected function tearDown(): void
-    {
-        array_map('unlink', glob("$this->dir/*.php"));
-        rmdir($this->dir);
-    }
 
     public function testDetectsLongMethod(): void
     {
@@ -31,13 +15,7 @@ class FindLongMethodsCommandTest extends TestCase
         $code = "<?php\nfunction longOne() {\n$body}\n";
         file_put_contents("$this->dir/test.php", $code);
 
-        $app = new Application();
-        File::clearCache();
-        Project::setRootPath($this->dir);
-
-        $command = $app->find('analyze:find-long-methods');
-        $tester = new CommandTester($command);
-        $tester->execute([
+        $tester = $this->runCommand('analyze:find-long-methods', [
             'path' => $this->dir,
             '--no-progress' => true,
             '--max' => 3,

--- a/tests/Commands/FindTodosCommandTest.php
+++ b/tests/Commands/FindTodosCommandTest.php
@@ -2,59 +2,34 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\Config;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class FindTodosCommandTest extends TestCase
+class FindTodosCommandTest extends CommandTestCase
 {
     public function testDetectsTodoComments(): void
     {
-        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
-        mkdir($dir);
-        file_put_contents("$dir/sample.php", "<?php\n// TODO: fix me\n");
+        file_put_contents("$this->dir/sample.php", "<?php\n// TODO: fix me\n");
 
-        $app = new Application();
-        File::clearCache();
-        Config::setContainer($app->getContainer());
-        Project::setRootPath($dir);
-
-        $command = $app->find('analyze:find-todos');
-        $tester = new CommandTester($command);
-        $tester->execute(['path' => $dir]);
+        $tester = $this->runCommand('analyze:find-todos', ['path' => $this->dir]);
 
         $display = $tester->getDisplay();
 
         $this->assertStringContainsString('TODO', $display);
-
-        unlink("$dir/sample.php");
-        rmdir($dir);
     }
 
     public function testNoProgressOptionDisablesProgressBar(): void
     {
-        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
-        mkdir($dir);
-        file_put_contents("$dir/sample.php", "<?php\n// TODO: fix me\n");
+        file_put_contents("$this->dir/sample.php", "<?php\n// TODO: fix me\n");
 
-        $app = new Application();
-        File::clearCache();
-        Config::setContainer($app->getContainer());
-        Project::setRootPath($dir);
-
-        $command = $app->find('analyze:find-todos');
-        $tester = new CommandTester($command);
-        $tester->execute(['path' => $dir, '--no-progress' => true]);
+        $tester = $this->runCommand('analyze:find-todos', [
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
 
         $display = $tester->getDisplay();
 
         $this->assertStringNotContainsString('Remaining:', $display);
         $this->assertStringContainsString('TODO', $display);
-
-        unlink("$dir/sample.php");
-        rmdir($dir);
     }
 }

--- a/tests/Commands/FindTyposCommandTest.php
+++ b/tests/Commands/FindTyposCommandTest.php
@@ -2,15 +2,11 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Process\ExecutableFinder;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\Config;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class FindTyposCommandTest extends TestCase
+class FindTyposCommandTest extends CommandTestCase
 {
     public function testDetectsTypos(): void
     {
@@ -19,24 +15,15 @@ class FindTyposCommandTest extends TestCase
             $this->markTestSkipped('Aspell not installed.');
         }
 
-        $dir = sys_get_temp_dir() . '/syntra_typo_' . uniqid();
-        mkdir($dir);
-        file_put_contents("$dir/teh_file.php", "<?php\n");
+        file_put_contents("$this->dir/teh_file.php", "<?php\n");
 
-        $app = new Application();
-        File::clearCache();
-        Config::setContainer($app->getContainer());
-        Project::setRootPath($dir);
-
-        $command = $app->find('analyze:find-typos');
-        $tester = new CommandTester($command);
-        $tester->execute(['path' => $dir, '--no-progress' => true]);
+        $tester = $this->runCommand('analyze:find-typos', [
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
 
         $display = $tester->getDisplay();
 
         $this->assertStringContainsString('teh', $display);
-
-        unlink("$dir/teh_file.php");
-        rmdir($dir);
     }
 }

--- a/tests/Commands/GenerateDocsCommandTest.php
+++ b/tests/Commands/GenerateDocsCommandTest.php
@@ -2,42 +2,31 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\Config;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class GenerateDocsCommandTest extends TestCase
+class GenerateDocsCommandTest extends CommandTestCase
 {
     public function testParametersIncluded(): void
     {
-        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
-        mkdir("$dir/backend/controllers", 0777, true);
-        copy(__DIR__ . '/../Fixtures/backend/controllers/SiteController.php', "$dir/backend/controllers/SiteController.php");
-        file_put_contents("$dir/composer.json", json_encode(['require' => ['yiisoft/yii2' => '*']]));
+        mkdir("$this->dir/backend/controllers", 0777, true);
+        copy(
+            __DIR__ . '/../Fixtures/backend/controllers/SiteController.php',
+            "$this->dir/backend/controllers/SiteController.php"
+        );
+        file_put_contents(
+            "$this->dir/composer.json",
+            json_encode(['require' => ['yiisoft/yii2' => '*']])
+        );
 
-        $app = new Application();
-        File::clearCache();
-        Config::setContainer($app->getContainer());
-        Project::setRootPath($dir);
-
-        $command = $app->find('general:generate-docs');
-        $tester = new CommandTester($command);
-        $tester->execute(['path' => $dir, '--no-progress' => true]);
-
-        $content = file_get_contents("$dir/docs/routes.md");
+        $tester = $this->runCommand('general:generate-docs', [
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
+        $content = file_get_contents("$this->dir/docs/routes.md");
 
         $this->assertMatchesRegularExpression('/\| `index`\s+\|\s+0\s+\|\s+string \$id, int \$page = 1\s+\|\s+Home page\s+\|/', $content);
         $this->assertMatchesRegularExpression('/\| `view`\s+\|\s+0\s+\|\s+\$slug\s+\|\s+\|/', $content);
 
-        unlink("$dir/backend/controllers/SiteController.php");
-        unlink("$dir/composer.json");
-        unlink("$dir/docs/routes.md");
-        rmdir("$dir/docs");
-        rmdir("$dir/backend/controllers");
-        rmdir("$dir/backend");
-        rmdir($dir);
     }
 }

--- a/tests/Commands/OutputFileTest.php
+++ b/tests/Commands/OutputFileTest.php
@@ -2,14 +2,12 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
 use Vix\Syntra\Commands\SyntraCommand;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class OutputFileTest extends TestCase
+class OutputFileTest extends CommandTestCase
 {
     private function makeCommand(): SyntraCommand
     {
@@ -30,11 +28,8 @@ class OutputFileTest extends TestCase
 
     public function testWritesToOutputFile(): void
     {
-        $app = new Application();
-        Project::setRootPath(sys_get_temp_dir());
-
         $command = $this->makeCommand();
-        $app->add($command);
+        $this->app->add($command);
         $tester = new CommandTester($command);
 
         $file = tempnam(sys_get_temp_dir(), 'syntra_log');

--- a/tests/Commands/RefactorAllFrameworkTest.php
+++ b/tests/Commands/RefactorAllFrameworkTest.php
@@ -2,31 +2,21 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
 use Vix\Syntra\Commands\Extension\Yii\YiiAllCommand;
 use Vix\Syntra\Commands\Refactor\RefactorAllCommand;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class RefactorAllFrameworkTest extends TestCase
+class RefactorAllFrameworkTest extends CommandTestCase
 {
     public function testRunsFrameworkCommandWhenOptionEnabled(): void
     {
-        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
-        mkdir($dir);
-        file_put_contents("$dir/composer.json", json_encode([
+        file_put_contents("$this->dir/composer.json", json_encode([
             'require' => [
                 'yiisoft/yii2' => '*',
             ],
         ]));
-
-        $app = new Application();
-        $container = $app->getContainer();
-        File::clearCache();
-        Project::setRootPath($dir);
 
         $command = new class () extends RefactorAllCommand {
             public array $executed = [];
@@ -37,13 +27,10 @@ class RefactorAllFrameworkTest extends TestCase
             }
         };
 
-        $app->add($command);
+        $this->app->add($command);
         $tester = new CommandTester($command);
         $tester->execute(['--framework' => true, '--force' => true]);
 
         $this->assertContains(YiiAllCommand::class, $command->executed);
-
-        unlink("$dir/composer.json");
-        rmdir($dir);
     }
 }

--- a/tests/Commands/StrictTypesCoverageCommandTest.php
+++ b/tests/Commands/StrictTypesCoverageCommandTest.php
@@ -2,51 +2,22 @@
 
 namespace Vix\Syntra\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Vix\Syntra\Application;
-use Vix\Syntra\Facades\File;
-use Vix\Syntra\Facades\Project;
+use Vix\Syntra\Tests\CommandTestCase;
 
-class StrictTypesCoverageCommandTest extends TestCase
+class StrictTypesCoverageCommandTest extends CommandTestCase
 {
-    private string $dir;
-
-    protected function setUp(): void
-    {
-        $this->dir = sys_get_temp_dir() . '/syntra_' . uniqid();
-        mkdir($this->dir);
-    }
-
-    protected function tearDown(): void
-    {
-        array_map('unlink', glob("$this->dir/*.php"));
-        rmdir($this->dir);
-    }
-
-    private function runCommand(): CommandTester
-    {
-        $app = new Application();
-        File::clearCache();
-        Project::setRootPath($this->dir);
-
-        $command = $app->find('analyze:strict-types');
-        $tester = new CommandTester($command);
-        $tester->execute([
-            'path' => $this->dir,
-            '--no-progress' => true,
-        ]);
-
-        return $tester;
-    }
 
     public function testSuccessWhenAllFilesDeclareStrict(): void
     {
         file_put_contents("$this->dir/a.php", "<?php\ndeclare(strict_types=1);\n");
         file_put_contents("$this->dir/b.php", "<?php\ndeclare(strict_types=1);\n");
 
-        $tester = $this->runCommand();
+        $tester = $this->runCommand('analyze:strict-types', [
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
 
         $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
         $this->assertStringContainsString('100.0%', $tester->getDisplay());
@@ -57,7 +28,10 @@ class StrictTypesCoverageCommandTest extends TestCase
         file_put_contents("$this->dir/a.php", "<?php\ndeclare(strict_types=1);\n");
         file_put_contents("$this->dir/b.php", "<?php echo 'no';\n");
 
-        $tester = $this->runCommand();
+        $tester = $this->runCommand('analyze:strict-types', [
+            'path' => $this->dir,
+            '--no-progress' => true,
+        ]);
 
         $this->assertSame(Command::FAILURE, $tester->getStatusCode());
         $this->assertStringContainsString('50.0%', $tester->getDisplay());


### PR DESCRIPTION
## Summary
- add `CommandTestCase` for repeated command test setup
- update command tests to extend the new base and use `runCommand`

## Testing
- `./vendor/bin/phpunit --no-coverage`

------
https://chatgpt.com/codex/tasks/task_e_686e25c948fc83228309de88a12546b5