### PR TITLE
Remove redundant container trait

### DIFF
--- a/src/Commands/Analyze/FindBadPracticesCommand.php
+++ b/src/Commands/Analyze/FindBadPracticesCommand.php
@@ -11,12 +11,10 @@ use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\NodeVisitors\AssignmentInConditionVisitor;
 use Vix\Syntra\NodeVisitors\NestedTernaryVisitor;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
-use Vix\Syntra\Traits\ContainerAwareTrait;
 use Vix\Syntra\Traits\ParsesPhpFilesTrait;
 
 class FindBadPracticesCommand extends SyntraCommand
 {
-    use ContainerAwareTrait;
     use AnalyzesFilesTrait;
     use ParsesPhpFilesTrait;
 

--- a/src/Commands/Analyze/FindLongMethodsCommand.php
+++ b/src/Commands/Analyze/FindLongMethodsCommand.php
@@ -11,12 +11,10 @@ use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\NodeVisitors\LongMethodVisitor;
 use Vix\Syntra\Traits\AnalyzesFilesTrait;
-use Vix\Syntra\Traits\ContainerAwareTrait;
 use Vix\Syntra\Traits\ParsesPhpFilesTrait;
 
 class FindLongMethodsCommand extends SyntraCommand
 {
-    use ContainerAwareTrait;
     use AnalyzesFilesTrait;
     use ParsesPhpFilesTrait;
 


### PR DESCRIPTION
## Summary
- drop ContainerAwareTrait from finders as ParsesPhpFilesTrait already includes it

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_686e3a464f60832283aae6cf73123840