### PR TITLE
Add config validation

### DIFF
--- a/src/Utils/ConfigLoader.php
+++ b/src/Utils/ConfigLoader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Vix\Syntra\Utils;
 
 use Vix\Syntra\Enums\CommandGroup;
+use Vix\Syntra\Exceptions\ConfigException;
 use Vix\Syntra\Utils\ProjectInfo;
 
 class ConfigLoader
@@ -28,9 +29,19 @@ class ConfigLoader
         $projectRoot = (new ProjectInfo())->getRootPath();
         $projectConfig = rtrim($projectRoot, '/') . '/syntra.php';
 
-        $this->commands = is_readable($projectConfig)
-            ? require $projectConfig
-            : require PACKAGE_ROOT . '/syntra.php';
+        $file = is_readable($projectConfig)
+            ? $projectConfig
+            : PACKAGE_ROOT . '/syntra.php';
+
+        $config = require $file;
+
+        if (!is_array($config)) {
+            throw new ConfigException("Config file '$file' must return an array");
+        }
+
+        ConfigValidator::validate($config);
+
+        $this->commands = $config;
     }
 
     public function getCommandConfig(string $group, string $commandClass): array|bool

--- a/src/Utils/ConfigValidator.php
+++ b/src/Utils/ConfigValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Utils;
+
+use Vix\Syntra\Exceptions\ConfigException;
+
+class ConfigValidator
+{
+    /**
+     * Validate Syntra configuration array structure.
+     *
+     * @throws ConfigException if the configuration is invalid
+     */
+    public static function validate(array $config): void
+    {
+        foreach ($config as $group => $commands) {
+            if (!is_array($commands)) {
+                throw new ConfigException("Config group '$group' must be an array");
+            }
+            foreach ($commands as $class => $cfg) {
+                if (!is_bool($cfg) && !is_array($cfg)) {
+                    throw new ConfigException("Config for command '$class' in group '$group' must be bool or array");
+                }
+                if (is_array($cfg) && array_key_exists('enabled', $cfg) && !is_bool($cfg['enabled'])) {
+                    throw new ConfigException("'enabled' option for command '$class' in group '$group' must be bool");
+                }
+            }
+        }
+    }
+}

--- a/tests/Utils/ConfigLoaderTest.php
+++ b/tests/Utils/ConfigLoaderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vix\Syntra\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Exceptions\ConfigException;
+use Vix\Syntra\Utils\ConfigLoader;
+
+class ConfigLoaderTest extends TestCase
+{
+    public function testThrowsForInvalidConfig(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        file_put_contents("$dir/composer.json", '{}');
+        file_put_contents("$dir/syntra.php", "<?php return 'invalid';");
+        $cwd = getcwd();
+        chdir($dir);
+
+        try {
+            $this->expectException(ConfigException::class);
+            new ConfigLoader();
+        } finally {
+            chdir($cwd);
+            unlink("$dir/syntra.php");
+            unlink("$dir/composer.json");
+            rmdir($dir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate `syntra.php` configuration before boot
- throw `ConfigException` when the config file isn't an array or has malformed options
- test invalid configuration handling

## Testing
- `./vendor/bin/phpunit tests/Utils/ConfigLoaderTest.php`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686e3d450d0c83229f4cfce96818f346