### PR TITLE
Add package check for Peck

### DIFF
--- a/src/Commands/Analyze/FindTyposCommand.php
+++ b/src/Commands/Analyze/FindTyposCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Process\ExecutableFinder;
 use Vix\Syntra\Commands\SyntraCommand;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Exceptions\MissingBinaryException;
+use Vix\Syntra\Exceptions\MissingPackageException;
 use Vix\Syntra\Facades\File;
 
 class FindTyposCommand extends SyntraCommand
@@ -32,6 +33,10 @@ class FindTyposCommand extends SyntraCommand
         $finder = new ExecutableFinder();
         if ($finder->find('aspell') === null) {
             throw new MissingBinaryException('aspell');
+        }
+
+        if (!class_exists(Kernel::class)) {
+            throw new MissingPackageException('peckphp/peck', 'composer require --dev peckphp/peck');
         }
 
         $kernel = Kernel::default();

--- a/src/Commands/SyntraCommand.php
+++ b/src/Commands/SyntraCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Vix\Syntra\Enums\ProgressIndicatorType;
 use Vix\Syntra\Exceptions\CommandException;
 use Vix\Syntra\Exceptions\MissingBinaryException;
+use Vix\Syntra\Exceptions\MissingPackageException;
 use Vix\Syntra\Facades\File;
 use Vix\Syntra\Facades\Installer;
 use Vix\Syntra\Facades\Project;
@@ -98,6 +99,8 @@ abstract class SyntraCommand extends Command
             return $this->perform();
         } catch (MissingBinaryException $e) {
             return $this->handleMissingBinary($e);
+        } catch (MissingPackageException $e) {
+            return $this->handleMissingPackage($e);
         } catch (CommandException $e) {
             $this->output->error($e->getMessage());
 
@@ -139,6 +142,16 @@ abstract class SyntraCommand extends Command
      * Handle MissingBinaryException uniformly across commands.
      */
     protected function handleMissingBinary(MissingBinaryException $e): int
+    {
+        $this->output->error($e->getMessage());
+
+        return self::FAILURE;
+    }
+
+    /**
+     * Handle MissingPackageException uniformly across commands.
+     */
+    protected function handleMissingPackage(MissingPackageException $e): int
     {
         $this->output->error($e->getMessage());
 

--- a/src/Exceptions/MissingBinaryException.php
+++ b/src/Exceptions/MissingBinaryException.php
@@ -6,14 +6,8 @@ namespace Vix\Syntra\Exceptions;
 
 class MissingBinaryException extends CommandException
 {
-    public function __construct(string $binary, public ?string $suggestedInstall = null)
+    public function __construct(string $binary)
     {
-        $message = "'$binary' is not installed.";
-
-        if ($suggestedInstall) {
-            $message .= "\nTo install: $suggestedInstall";
-        }
-
-        parent::__construct($message);
+        parent::__construct("'$binary' is not installed.");
     }
 }

--- a/src/Exceptions/MissingPackageException.php
+++ b/src/Exceptions/MissingPackageException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Exceptions;
+
+class MissingPackageException extends CommandException
+{
+    public function __construct(string $package, public ?string $suggestedInstall = null)
+    {
+        $message = "'$package' package is not installed.";
+
+        if ($suggestedInstall) {
+            $message .= "\nTo install: $suggestedInstall";
+        }
+
+        parent::__construct($message);
+    }
+}

--- a/src/Traits/HasBinaryTool.php
+++ b/src/Traits/HasBinaryTool.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Vix\Syntra\Traits;
 
-use Vix\Syntra\Exceptions\MissingBinaryException;
+use Vix\Syntra\Exceptions\MissingPackageException;
 use Vix\Syntra\Facades\Project;
 use Vix\Syntra\Tools\ToolInterface;
 
@@ -17,7 +17,7 @@ trait HasBinaryTool
         $this->binary = find_composer_bin($tool->binaryName(), Project::getRootPath());
 
         if (!$this->binary) {
-            throw new MissingBinaryException($tool->binaryName(), $tool->installCommand());
+            throw new MissingPackageException($tool->packageName(), $tool->installCommand());
         }
     }
 }

--- a/src/Utils/RectorCommandExecutor.php
+++ b/src/Utils/RectorCommandExecutor.php
@@ -8,7 +8,7 @@ use Vix\Syntra\Commands\Refactor\RectorRefactorer;
 use Vix\Syntra\DTO\ProcessResult;
 use Vix\Syntra\Enums\CommandGroup;
 use Vix\Syntra\Enums\Tool;
-use Vix\Syntra\Exceptions\MissingBinaryException;
+use Vix\Syntra\Exceptions\MissingPackageException;
 use Vix\Syntra\Facades\Config;
 use Vix\Syntra\Facades\Process;
 use Vix\Syntra\Traits\HasBinaryTool;
@@ -29,7 +29,7 @@ class RectorCommandExecutor
      * @return ProcessResult The result of the last executed rule. If no rules
      *                       are provided, a successful empty result is returned.
      *
-     * @throws MissingBinaryException
+     * @throws MissingPackageException
      */
     public function executeRules(string $path, array $rectorClasses, array $additionalArgs = [], ?callable $outputCallback = null): ProcessResult
     {


### PR DESCRIPTION
## Summary
- add a `MissingPackageException`
- warn when peckphp/peck is missing in `FindTyposCommand`
- handle missing packages in base command class
- simplify handling of missing binaries and throw `MissingPackageException` for missing tools

## Testing
- `composer test`