### PR TITLE
Fix root path detection fallback

### DIFF
--- a/src/Utils/ProjectInfo.php
+++ b/src/Utils/ProjectInfo.php
@@ -28,7 +28,8 @@ class ProjectInfo
         while (!file_exists("$dir/composer.json")) {
             $parent = dirname($dir);
             if ($parent === $dir) {
-                break;
+                // Reached filesystem root without locating composer.json
+                return rtrim($cwd, '/');
             }
             $dir = $parent;
         }

--- a/tests/Utils/ProjectInfoTest.php
+++ b/tests/Utils/ProjectInfoTest.php
@@ -68,4 +68,20 @@ class ProjectInfoTest extends TestCase
         unlink("$dir/composer.json");
         rmdir($dir);
     }
+
+    public function testGetRootPathFallsBackToCwd(): void
+    {
+        $dir = sys_get_temp_dir() . '/syntra_test_' . uniqid();
+        mkdir($dir);
+        $cwd = getcwd();
+        chdir($dir);
+
+        try {
+            $info = new ProjectInfo();
+            $this->assertSame($dir, $info->getRootPath());
+        } finally {
+            chdir($cwd);
+            rmdir($dir);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- stop `detectRootPath()` returning `/` when composer.json is missing
- ensure `ProjectInfo` falls back to the working directory
- add unit test for fallback logic

## Testing
- `composer test`