### PR TITLE
Refactor file iteration

### DIFF
--- a/src/Traits/AnalyzesFilesTrait.php
+++ b/src/Traits/AnalyzesFilesTrait.php
@@ -11,6 +11,8 @@ use Vix\Syntra\Facades\File;
  */
 trait AnalyzesFilesTrait
 {
+    use IteratesFilesTrait;
+
     /**
      * Collect all PHP files within the current path.
      *
@@ -30,25 +32,5 @@ trait AnalyzesFilesTrait
     {
         $files = $this->collectFiles();
         $this->iterateFiles($files, $callback);
-    }
-
-    /**
-     * Iterate over the given items with progress indicators.
-     *
-     * @template T
-     * @param array<T>         $items
-     * @param callable(T):void $callback
-     */
-    protected function iterateFiles(array $items, callable $callback): void
-    {
-        $this->setProgressMax(count($items));
-        $this->startProgress();
-
-        foreach ($items as $item) {
-            $callback($item);
-            $this->advanceProgress();
-        }
-
-        $this->finishProgress();
     }
 }

--- a/src/Traits/IteratesFilesTrait.php
+++ b/src/Traits/IteratesFilesTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Traits;
+
+trait IteratesFilesTrait
+{
+    /**
+     * Iterate over the given items with progress indicators.
+     *
+     * @template T
+     * @param array<T>         $items
+     * @param callable(T):void $callback
+     */
+    protected function iterateFiles(array $items, callable $callback): void
+    {
+        $this->setProgressMax(count($items));
+        $this->startProgress();
+
+        foreach ($items as $item) {
+            $callback($item);
+            $this->advanceProgress();
+        }
+
+        $this->finishProgress();
+    }
+}

--- a/src/Traits/ProcessesFilesTrait.php
+++ b/src/Traits/ProcessesFilesTrait.php
@@ -12,6 +12,7 @@ use Vix\Syntra\Facades\File;
  */
 trait ProcessesFilesTrait
 {
+    use IteratesFilesTrait;
     /**
      * Collect files, process them with the provided callback and list changed files.
      *
@@ -21,10 +22,7 @@ trait ProcessesFilesTrait
     {
         $files = File::collectFiles($this->path);
 
-        $this->setProgressMax(count($files));
-        $this->startProgress();
-
-        foreach ($files as $filePath) {
+        $this->iterateFiles($files, function (string $filePath) use ($processor): void {
             $content = file_get_contents($filePath);
 
             $newContent = $processor($content, $filePath);
@@ -32,11 +30,7 @@ trait ProcessesFilesTrait
             if (!$this->dryRun) {
                 File::writeChanges($filePath, $content, $newContent);
             }
-
-            $this->advanceProgress();
-        }
-
-        $this->finishProgress();
+        });
 
         $changed = File::getChangedFiles();
         File::clearChangedFiles();


### PR DESCRIPTION
## Summary
- centralize file iteration logic in `IteratesFilesTrait`
- reuse it in `AnalyzesFilesTrait` and `ProcessesFilesTrait`

## Testing
- `composer test`
- `composer phpstan` *(fails: At least one path must be specified to analyse)*
- `composer lint` *(fails: php-cs-fixer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e1e25a4832293278acd9265c3e3