### PR TITLE
Handle missing directories in FileHelper

### DIFF
--- a/src/Exceptions/DirectoryNotFoundException.php
+++ b/src/Exceptions/DirectoryNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Exceptions;
+
+use Exception;
+
+class DirectoryNotFoundException extends Exception
+{
+    public function __construct(string $dir)
+    {
+        parent::__construct("Directory '$dir' does not exist.");
+    }
+}

--- a/src/Utils/FileHelper.php
+++ b/src/Utils/FileHelper.php
@@ -42,6 +42,10 @@ class FileHelper
      */
     public function collectFiles(string $dir, array $extensions = ['php'], array $excludeDirs = ['vendor', 'tests']): array
     {
+        if (!is_dir($dir)) {
+            throw new \Vix\Syntra\Exceptions\DirectoryNotFoundException($dir);
+        }
+
         $cacheKey = md5($dir . '|' . implode(',', $extensions) . '|' . implode(',', $excludeDirs));
         if (Cache::has($cacheKey)) {
             /** @var string[] */

--- a/tests/Utils/FileHelperTest.php
+++ b/tests/Utils/FileHelperTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vix\Syntra\Tests\Utils;
+
+use PHPUnit\Framework\TestCase;
+use Vix\Syntra\Exceptions\DirectoryNotFoundException;
+use Vix\Syntra\Utils\FileHelper;
+
+class FileHelperTest extends TestCase
+{
+    public function testCollectFilesThrowsForMissingDirectory(): void
+    {
+        $helper = new FileHelper();
+
+        $this->expectException(DirectoryNotFoundException::class);
+        $helper->collectFiles(sys_get_temp_dir() . '/nonexistent_' . uniqid());
+    }
+}


### PR DESCRIPTION
## Summary
- throw `DirectoryNotFoundException` when collectFiles target directory does not exist
- add tests for the new behaviour

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686e4e97e62c83229b42fceaccfc7707