### PR TITLE
Fix forwarding of path in refactor:all

### DIFF
--- a/src/Commands/Refactor/RefactorAllCommand.php
+++ b/src/Commands/Refactor/RefactorAllCommand.php
@@ -45,7 +45,11 @@ class RefactorAllCommand extends SyntraRefactorCommand
 
     public function perform(): int
     {
-        $hasErrors = $this->runSubCommands('\\Commands\\Refactor\\');
+        $hasErrors = $this->runSubCommands(
+            '\\Commands\\Refactor\\',
+            null,
+            $this->getForwardOptions()
+        );
 
         if ($this->runFramework) {
             $type = Project::detect(Project::getRootPath());
@@ -75,7 +79,9 @@ class RefactorAllCommand extends SyntraRefactorCommand
      */
     private function getForwardOptions(): array
     {
-        $opts = [];
+        $opts = [
+            'path' => $this->path,
+        ];
         if ($this->dryRun) {
             $opts['--dry-run'] = true;
         }


### PR DESCRIPTION
## Summary
- pass CLI options when running subcommands in `refactor:all`
- include the current path when forwarding options to subcommands

## Testing
- `vendor/bin/phpunit -c phpunit.xml --stop-on-failure`